### PR TITLE
Some improvements to de_DE.lang

### DIFF
--- a/assets/opencomputers/lang/de_DE.lang
+++ b/assets/opencomputers/lang/de_DE.lang
@@ -112,6 +112,7 @@ oc:tooltip.RedstoneCard.RedLogic=§fRedLogic§7 wird §aunterstützt§7.
 oc:tooltip.RedstoneCard.RedNet=§fRedNet§7 wird §aunterstützt§7.
 oc:tooltip.RedstoneCard=Erlaubt das Lesen und Ausgeben von Redstonesignalen um den Computer oder Roboter herum.
 oc:tooltip.Robot=Im Gegensatz zu normalen Computern können sich Roboter in der Welt bewegen und ähnlich wie Spieler mit der Welt interagieren. Sie können jedoch §onicht§r§7 mit externen Komponenten interagieren!
+# The underscore makes sure this isn't hidden with the rest of the tooltip.
 oc:tooltip.Robot_Level=§fStufe§7: §a%s§7.
 oc:tooltip.Robot_StoredEnergy=§fGespeicherte Energie§7: §a%s§7.
 oc:tooltip.Router=Erlaubt es, mehrere Netzwerke miteinander zu verbinden. Leitet ausschließlich Netzwerknachrichten weiter, Komponenten "hinter" dem Router sind nicht sichtbar. Nützlich um Netzwerke zu trennen, jedoch nach wie vor Kommunikation zwischen den Netzwerken zu erlauben, z.b. mittels Netzwerkkarten.

--- a/assets/opencomputers/lang/de_DE.lang
+++ b/assets/opencomputers/lang/de_DE.lang
@@ -1,3 +1,7 @@
+#German (de_DE) localization file
+#Translations might not me 100% correct
+#Suggestions for improvements are welcome
+
 # Blocks
 oc:block.Adapter.name=Adapter
 oc:block.Cable.name=Kabel
@@ -10,7 +14,7 @@ oc:block.DiskDrive.name=Diskettenlaufwerk
 oc:block.Keyboard.name=Tastatur
 oc:block.PowerConverter.name=Leistungswandler
 oc:block.PowerDistributor.name=Stromverteiler
-oc:block.Redstone.name=Redstone E/A
+oc:block.Redstone.name=Redstone-I/O
 oc:block.Robot.name=Roboter
 oc:block.RobotAfterimage.name=Roboter
 oc:block.Router.name=Router
@@ -19,6 +23,7 @@ oc:block.Screen1.name=Hochwertiger Bildschirm
 oc:block.Screen2.name=Ausgezeichneter Bildschirm
 
 # Items
+oc:item.Acid.name=Grog
 oc:item.ALU.name=Arithmetisch-logische Einheit (ALU)
 oc:item.Analyzer.name=Messgerät
 oc:item.ArrowKeys.name=Pfeiltasten
@@ -45,11 +50,11 @@ oc:item.PrintedCircuitBoard.name=Gedruckte Leiterplatte (PCB)
 oc:item.RawCircuitBoard.name=Leiterplattenrohling
 oc:item.RedstoneCard.name=Redstonekarte
 oc:item.Transistor.name=Transistor
-oc:item.UpgradeCrafting.name=Crafting Upgrade
-oc:item.UpgradeGenerator.name=Generator Upgrade
+oc:item.UpgradeCrafting.name=Fertigungs-Upgrade
+oc:item.UpgradeGenerator.name=Generator-Upgrade
 oc:item.UpgradeNavigation.name=Navigationsupgrade
-oc:item.UpgradeSign.name=Schild-E/A Upgrade
-oc:item.UpgradeSolarGenerator.name=Solar Generator Upgrade
+oc:item.UpgradeSign.name=Schild-I/O Upgrade
+oc:item.UpgradeSolarGenerator.name=Solargenerator-Upgrade
 oc:item.WirelessNetworkCard.name=Drahtlosnetzwerkkarte
 
 # GUI
@@ -73,49 +78,49 @@ oc:container.DiskDrive=Diskettenlaufwerk
 
 # Item / Block Tooltips
 oc:tooltip.Acid=Eine hochgiftige Möchtegernflüssigkeit, wird üblicherweise nur von gewissen Piraten konsumiert. Dank ihrer korrosiven Eigenschaften ideal zum Bedrucken von Leiterplatten geeignet.
-oc:tooltip.Adapter=Erlaubt es Blöcke anzusteuern die keine Komponentenblöcke sind, wie etwa reguläre Minecraft Blöcke oder Blöcke anderer Mods.
+oc:tooltip.Adapter=Erlaubt es Blöcke anzusteuern, die keine Komponentenblöcke sind, wie etwa reguläre Minecraft-Blöcke oder Blöcke anderer Mods.
 oc:tooltip.ALU=Zählt Zahlen zum Zeitvertreib. Klingt komisch, is aber so.
-oc:tooltip.Analyzer=Erlaubt es Informationen über Blöcke anzuzeigen, wie zum Bleistift ihre §fAdresse§7 und ihren §fKomponentennamen§7.[nl] Erlaubt zudem den Fehler anzuzeigen der zu einem Computerabsturz geführt hat, falls der Computer nicht regulär heruntergefahren wurde.
-oc:tooltip.Cable=Ein billiger Weg verschiedene Blöcke miteinander zu verbinden.
-oc:tooltip.Capacitor=Speichert Energie für spätere Verwendung. Kann extrem schnell befüllt und entlehrt werden.
-oc:tooltip.CardBase=Wie der Name schon sagt werden alle Erweiterungskarten hieraus hergestellt.
+oc:tooltip.Analyzer=Erlaubt es Informationen über Blöcke anzuzeigen, wie zum Bleistift ihre §fAdresse§7 und ihren §fKomponentennamen§7.[nl] Erlaubt zudem, den Fehler anzuzeigen, der zu einem Computerabsturz geführt hat, falls der Computer nicht regulär heruntergefahren wurde.
+oc:tooltip.Cable=Ein billiger Weg, verschiedene Blöcke miteinander zu verbinden.
+oc:tooltip.Capacitor=Speichert Energie für spätere Verwendung. Kann extrem schnell befüllt und entleert werden.
+oc:tooltip.CardBase=Wie der Name schon sagt, werden alle Erweiterungskarten hieraus hergestellt.
 oc:tooltip.Case=Das Computergehäuse ist der essentielle Grundbaustein für einen Computer. §fErweiterungskarten§7, §fRAM§7 und §fFestplatten§7 können in einem Gehäuse installiert werden.[nl] Slots: §f%s§7.
-oc:tooltip.Charger=Lädt Roboter mit Energie aus Kondensatoren auf. Die Ladegeschwindigkeit hängt vom eingehenden §fRedstonesignal§7 ab, wobei kein Signal heißt "nicht laden", und ein Signal mit maximaler Stärke heißt "lade schnellstmöglich".
-oc:tooltip.CircuitBoard=Mühselig vermehrt sich das Eichhörnchen. Wenn es groß wird, wird es mal eine gedruckte Leiterplatte.
+oc:tooltip.Charger=Lädt Roboter mit Energie aus Kondensatoren auf. Die Ladegeschwindigkeit hängt vom eingehenden §fRedstonesignal§7 ab, wobei kein Signal "nicht laden" und ein Signal mit maximaler Stärke "schnellstmöglich laden" heißt.
+oc:tooltip.CircuitBoard=Mühsam ernährt sich das Eichhörnchen. Wenn es groß wird, wird es mal eine gedruckte Leiterplatte.
 oc:tooltip.ControlUnit=Klingt wichtig, ist es auch. Man baut daraus immerhin CPUs. Wie könnte es da nicht wichtig sein.
 oc:tooltip.CPU=Kernstück eines jeden Computers. Die Taktrate hat einen leichten Schatten, aber was kann man von einer Taschensonnenuhr schon erwarten?
-oc:tooltip.CuttingWire=Wird gebraucht um Tonblöcke in Leiterplattenform zu bekommen. Vermutlich das ineffizienteste Werkzeug in der Geschichte der Menschheit, da es nach einer Verwendung kaputt geht.
-oc:tooltip.Disk=Sehr einfaches Speichermedium das verwendet werden kann um Disketten und Festplatten bauen.
-oc:tooltip.DiskDrive.CC=ComputerCraft Disketten werden §aunterstützt§7.
-oc:tooltip.DiskDrive=Erlaubt es Disketten zu lesen und zu beschreiben.
-oc:tooltip.GraphicsCard=Erlaubt es den angezeigten Inhalt von Bildschirmen zu ändern.[nl] Höchstauflösung: §f%sx%s§7.[nl] Maximale Farbtiefe: §f%s§7.[nl] Operationen/Tick: §f%s§7.
-oc:tooltip.IronNugget=Ein Nugget das aus Eisen besteht, darum wird es ja auch Eisennugget genannt, duh...
-oc:tooltip.Keyboard=Kann an Bildschirmen befestigt werden um auf ihnen zu tippen.
-oc:tooltip.Memory=Braucht ein jeder Computer um zu starten. Je mehr vorhanden, desto komplexere Programme können ausgeführt werden.
-oc:tooltip.Microchip=Tritt auch unter dem Alias Integrierter Schaltkreis auf. Keine Ahnung warum das auch mit Redstone klappt, aber es funktioniert.
-oc:tooltip.NetworkCard=Erlaubt es Computern die über mehrere Blöcke miteinander verbunden sind (z.B. Kabel) mittels Netzwerknachrichten zu kommunizieren.
+oc:tooltip.CuttingWire=Wird gebraucht, um Tonblöcke in Leiterplattenform zu bekommen. Vermutlich das ineffizienteste Werkzeug in der Geschichte der Menschheit, da es nach einer Verwendung kaputt geht.
+oc:tooltip.Disk=Sehr einfaches Speichermedium, das verwendet werden kann, um Disketten und Festplatten bauen.
+oc:tooltip.DiskDrive.CC=ComputerCraft-Disketten werden §aunterstützt§7.
+oc:tooltip.DiskDrive=Erlaubt es, Disketten zu lesen und zu beschreiben.
+oc:tooltip.GraphicsCard=Erlaubt es, den angezeigten Inhalt von Bildschirmen zu ändern.[nl] Höchstauflösung: §f%sx%s§7.[nl] Maximale Farbtiefe: §f%s§7.[nl] Operationen/Tick: §f%s§7.
+oc:tooltip.IronNugget=Ein Nugget, das aus Eisen besteht, darum wird es ja auch Eisennugget genannt, duh...
+oc:tooltip.Keyboard=Kann an Bildschirmen befestigt werden, um auf ihnen zu tippen.
+oc:tooltip.Memory=Braucht ein jeder Computer, um zu starten. Je mehr vorhanden, desto komplexere Programme können ausgeführt werden.
+oc:tooltip.Microchip=Tritt auch unter dem Alias Integrierter Schaltkreis auf. Keine Ahnung, warum das auch mit Redstone klappt, aber es funktioniert.
+oc:tooltip.NetworkCard=Erlaubt es Computern, die über mehrere Blöcke miteinander verbunden sind (z.B. Kabel), mittels Netzwerknachrichten zu kommunizieren.
 oc:tooltip.PowerConverter.BC=§fBuildCraft MJ§7: §a%s:%s§7.
 oc:tooltip.PowerConverter.IC2=§fIndustrialCraft² EU§7: §a%s:%s§7.
 oc:tooltip.PowerConverter.TE=§fThermal Expansion RF§7: §a%s:%s§7.
 oc:tooltip.PowerConverter.UE=§fUniversal Electricity Joules§7: §a%s:%s§7.
 oc:tooltip.PowerConverter=Wandelt Strom anderer Mods in den internen Energietyp um. Umwandlungsverhältnisse:
-oc:tooltip.PowerDistributor=Verteilt Energie zwischen mehreren Netwerken. Nützlich um Energie mit einem Wandler auf mehrere Subnetze, die voneinander getrennt sein sollen, zu verteilen.
-oc:tooltip.PrintedCircuitBoard=Hierauf basieren alle alle Erweiterungskarten, Speicher und so weiter.
-oc:tooltip.RawCircuitBoard=Kann in einer Ofenkompatiblen Schmelze freier Wahl gehärtet werden.
-oc:tooltip.Redstone=Erlaubt das Lesen und Ausgeben von Redstonesignalen um den Block herum. Kann von jedem Computer der mit dem Block verbunden ist gesteuert werden. Dieser Block ist quasi wie eine externe Redstonekarte.
+oc:tooltip.PowerDistributor=Verteilt Energie zwischen mehreren Netzwerken. Nützlich, um Energie mit einem Wandler auf mehrere Subnetze, die voneinander getrennt sein sollen, zu verteilen.
+oc:tooltip.PrintedCircuitBoard=Hierauf basieren alle Erweiterungskarten, Speicher und so weiter.
+oc:tooltip.RawCircuitBoard=Kann in einer ofenkompatiblen Schmelze freier Wahl gehärtet werden.
+oc:tooltip.Redstone=Erlaubt das Lesen und Ausgeben von Redstonesignalen um den Block herum. Kann von jedem Computer, der mit dem Block verbunden ist, gesteuert werden. Dieser Block ist quasi wie eine externe Redstonekarte.
 oc:tooltip.RedstoneCard.RedLogic=§fRedLogic§7 wird §aunterstützt§7.
 oc:tooltip.RedstoneCard.RedNet=§fRedNet§7 wird §aunterstützt§7.
 oc:tooltip.RedstoneCard=Erlaubt das Lesen und Ausgeben von Redstonesignalen um den Computer oder Roboter herum.
 oc:tooltip.Robot=Im Gegensatz zu normalen Computern können sich Roboter in der Welt bewegen und ähnlich wie Spieler mit der Welt interagieren. Sie können jedoch §onicht§r§7 mit externen Komponenten interagieren!
 oc:tooltip.Robot_Level=§fStufe§7: §a%s§7.
 oc:tooltip.Robot_StoredEnergy=§fGespeicherte Energie§7: §a%s§7.
-oc:tooltip.Router=Erlaubt es mehrere Netzwerke miteinander zu verbinden. Leitet ausschließlich Netzwerknachrichten weiter, Komponenten "hinter" dem Router sind nicht sichtbar. Nützlich um Netzwerke zu trennen, jedoch nach wie vor Kommunikation zwischen den Netzwerken zu erlauben, z.b. mittels Netzwerkkarten.
+oc:tooltip.Router=Erlaubt es, mehrere Netzwerke miteinander zu verbinden. Leitet ausschließlich Netzwerknachrichten weiter, Komponenten "hinter" dem Router sind nicht sichtbar. Nützlich um Netzwerke zu trennen, jedoch nach wie vor Kommunikation zwischen den Netzwerken zu erlauben, z.b. mittels Netzwerkkarten.
 oc:tooltip.Screen=Zeigt Text an, gesteuert von Grafikkarten in Computern.[nl] Höchstauflösung: §f%sx%s§7.[nl] Maximale Farbtiefe: §f%s§7.
 oc:tooltip.TooLong=Shift gedrückt halten für mehr Infos.
 oc:tooltip.Transistor=Elementarer Baustein der meisten Computerkomponenten. Nicht zu verwechseln mit Steinelementaren.
-oc:tooltip.UpgradeCrafting=Ermöglicht Robotern in dem oberen linken Bereich ihres Inventars zu craften. Gegenstände müssen so angeordnet sein wie sie es in einer Werkbank wären.
-oc:tooltip.UpgradeGenerator=Kann verwendet werden um unterwegs Energie aus Brennstoffen zu erzeugen. Verbraucht Gegenstände über einen ihrem Brennwert gemäßen Zeitraum.[nl] §fEffizienz§7: §a%s%%§7
-oc:tooltip.UpgradeNavigation=Erlaubt es Robotern ihre Position und Ausrichtung zu bestimmen. Die Position ist relativ zur Mitte der Karte, die in diesem Upgrade verbaut wurde.
+oc:tooltip.UpgradeCrafting=Ermöglicht Robotern, in dem oberen linken Bereich ihres Inventars Dinge zu fertigen. Gegenstände müssen so angeordnet sein, wie sie es in einer Werkbank wären.
+oc:tooltip.UpgradeGenerator=Kann verwendet werden, um unterwegs Energie aus Brennstoffen zu erzeugen. Verbraucht Gegenstände über einen ihrem Brennwert gemäßen Zeitraum.[nl] §fEffizienz§7: §a%s%%§7
+oc:tooltip.UpgradeNavigation=Erlaubt es Robotern, ihre Position und Ausrichtung zu bestimmen. Die Position ist relativ zur Mitte der Karte, die in diesem Upgrade verbaut wurde.
 oc:tooltip.UpgradeSign=Erlaubt das Lesen und Schreiben von Text auf Schildern.
-oc:tooltip.UpgradeSolarGenerator=Kann verwendet werden um unterwegs Energie aus Sonnenlicht zu generieren. Benötigt eine ungehinderte Sicht zum Himmel über dem Roboter. Generiert Energie mit %s%% der Geschwindigkeit einer Stirling Engine.
+oc:tooltip.UpgradeSolarGenerator=Kann verwendet werden, um unterwegs Energie aus Sonnenlicht zu generieren. Benötigt eine ungehinderte Sicht zum Himmel über dem Roboter. Generiert Energie mit %s%% der Geschwindigkeit eines Stirlingmotors.
 oc:tooltip.WirelessNetworkCard=Erlaubt das drahtlose Senden von Netzwerknachrichten, zusätzlich zu normalen. Drahtlose Nachrichten werden nur gesendet, wenn eine §fSignalstärke§7 festgelegt wurde!


### PR DESCRIPTION
I think I/O should stay English, the rest is mostly grammar improvements and commas and hyphens, since German language uses quite a lot of them.
