### PR TITLE
Fixed package module to propagate erros from loading module

### DIFF
--- a/assets/opencomputers/lua/rom/lib/package.lua
+++ b/assets/opencomputers/lua/rom/lib/package.lua
@@ -58,7 +58,12 @@ end
 local function pathSearcher(module)
   local filepath, reason = package.searchpath(module, package.path)
   if filepath then
-    return loadfile(filepath, "bt", _G), filepath
+    local loader, reason = loadfile(filepath, "bt", _G), filepath
+    if loader then
+      return loader, filepath
+    else
+      return reason
+    end
   else
     return reason
   end


### PR DESCRIPTION
When Lua finds an error while loading the package, the current `require` just errors and returns. I changed it so that `pathSearcher` now checks to see if the loader is actually loaded, and otherwise return the error returned by `loadfile`. 
