### PR TITLE
Added :gsub("\\\n","\\n") to string serialization

### DIFF
--- a/src/main/resources/assets/opencomputers/lua/rom/lib/serialization.lua
+++ b/src/main/resources/assets/opencomputers/lua/rom/lib/serialization.lua
@@ -28,7 +28,7 @@ function serialization.serialize(value, pretty)
         return tostring(v)
       end
     elseif t == "string" then
-      return string.format("%q", v)
+      return string.format("%q", v):gsub("\\\n","\\n")
     elseif t == "table" and pretty and getmetatable(v) and getmetatable(v).__tostring then
       return tostring(v)
     elseif t == "table" then


### PR DESCRIPTION
this is because string.format("q","\n")=="\\n"
which can break some database programs that assume 1 serialized object per line
