### PR TITLE
allow system to catch too long without yielding

### DIFF
--- a/src/main/resources/assets/opencomputers/lua/kernel.lua
+++ b/src/main/resources/assets/opencomputers/lua/kernel.lua
@@ -6,7 +6,7 @@ local function checkDeadline()
     debug.sethook(coroutine.running(), checkDeadline, "", 1)
     if not hitDeadline then
       deadline = deadline + 0.5
-  	end
+    end
     hitDeadline = true
     error("too long without yielding", 0)
   end

--- a/src/main/resources/assets/opencomputers/lua/kernel.lua
+++ b/src/main/resources/assets/opencomputers/lua/kernel.lua
@@ -1,8 +1,13 @@
 local hookInterval = 100
 local deadline = math.huge
+local hitDeadline = false
 local function checkDeadline()
   if computer.realTime() > deadline then
     debug.sethook(coroutine.running(), checkDeadline, "", 1)
+    if not hitDeadline then
+      deadline = deadline + 0.5
+  	end
+    hitDeadline = true
     error("too long without yielding", 0)
   end
 end
@@ -570,6 +575,7 @@ local function main()
 
   while true do
     deadline = computer.realTime() + timeout -- timeout global is set by host
+    hitDeadline = false
     debug.sethook(co, checkDeadline, "", hookInterval)
     local result = table.pack(coroutine.resume(co, table.unpack(args, 1, args.n)))
     if not result[1] then


### PR DESCRIPTION
gives system 0.5 seconds to yield before crashing.
makes it much much less annoying, and its still safe:
while true do end -> error
while true do pcall(function() while true do end end) end -> system crash
http://puu.sh/8ahiP.png
