### PR TITLE
Add support for ComputerCraft Events

### DIFF
--- a/src/main/scala/li/cil/oc/server/driver/Registry.scala
+++ b/src/main/scala/li/cil/oc/server/driver/Registry.scala
@@ -91,9 +91,11 @@ private[oc] object Registry extends api.detail.DriverAPI {
       case (value: AnyRef) => convertRecursively(value)
     }
     case arg: Map[_, _] => arg.map {
+      case (key: AnyRef, null) =>convertRecursively(key) -> null
       case (key: AnyRef, value: AnyRef) => convertRecursively(key) -> convertRecursively(value)
     }
     case arg: java.util.Map[_, _] => arg.map {
+      case (key: AnyRef, null) =>convertRecursively(key) -> null
       case (key: AnyRef, value: AnyRef) => convertRecursively(key) -> convertRecursively(value)
     }
 


### PR DESCRIPTION
Add support for ComputerCraft Events
fix: https://github.com/MightyPirates/OpenComputers/issues/252
Now it wraps the peripheral correctly and returns proper values instead of null/nil.

"It always seems impossible until its done." - Nelson Mandela
