### PR TITLE
Update default.recipes

### DIFF
--- a/src/main/resources/assets/opencomputers/recipes/default.recipes
+++ b/src/main/resources/assets/opencomputers/recipes/default.recipes
@@ -205,9 +205,9 @@ cpu1 {
           [nuggetGold, "oc:craftingALU", nuggetGold]]
 }
 cpu2 {
-  input: [[emerald, redstone, emerald]
+  input: [[diamond, redstone, diamond]
           ["oc:circuitTier3", "oc:craftingCU", "oc:circuitTier3"]
-          [emerald, "oc:craftingALU", emerald]]
+          [diamond, "oc:craftingALU", diamond]]
 }
 cu {
   input: [[nuggetGold, redstone, nuggetGold]


### PR DESCRIPTION
The recipe for cpu2 now uses diamonds instead of emeralds. It didn't match the nuggetIron -> nuggetGold -> diamond pattern used by all other components.
