### PR TITLE
Allow installation on 1 Tier1 memory

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/install.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/install.lua
@@ -2,6 +2,7 @@ local component = require("component")
 local computer = require("computer")
 local event = require("event")
 local unicode = require("unicode")
+local shell = require("shell")
 
 local candidates = {}
 for address in component.list("filesystem") do
@@ -39,12 +40,14 @@ repeat
 until choice
 choice = candidates[choice]
 
+local cp = loadfile(shell.resolve("cp","lua"))
+
 print("Installing OpenOS to device " .. choice.address)
 local boot = "/mnt/" .. computer.getBootAddress():sub(1, 3) .. "/"
 local mnt = "/mnt/" .. choice.address:sub(1, 3) .. "/"
 local function install(what, path)
   print("Installing " .. what .. "...")
-  local result, reason = os.execute("cp -vf " .. boot .. path .. " " .. mnt)
+  local result, reason = pcall(cp,"-vf",boot .. path,mnt)
   if not result then
     error(reason, 0)
   end


### PR DESCRIPTION
Before, installation would crash half way through with "not enough memory", and a partially copied OpenOS is left on the disk.
