### PR TITLE
Made Disk Drives react to right clicks.

### DIFF
--- a/src/main/resources/assets/opencomputers/robot.names
+++ b/src/main/resources/assets/opencomputers/robot.names
@@ -13,6 +13,7 @@ Vexatos
 Wobbo
 YuRaNnNzZZ
 Kodos
+Kilobyte
 
 # Names of more or less famous robots, as a bit of filler material. Feel free
 # to add more via pull requests. Let's hope this won't get us sued...

--- a/src/main/scala/li/cil/oc/common/block/DiskDrive.scala
+++ b/src/main/scala/li/cil/oc/common/block/DiskDrive.scala
@@ -67,12 +67,26 @@ class DiskDrive(val parent: SimpleDelegator) extends SimpleDelegate {
 
   override def rightClick(world: World, x: Int, y: Int, z: Int, player: EntityPlayer,
                           side: ForgeDirection, hitX: Float, hitY: Float, hitZ: Float) = {
+    val te = world.getBlockTileEntity(x, y, z).asInstanceOf[tileentity.DiskDrive]
     if (!player.isSneaking) {
-      if (!world.isRemote) {
-        player.openGui(OpenComputers, GuiType.DiskDrive.id, world, x, y, z)
+      if (te.isItemValidForSlot(0, player.getCurrentEquippedItem)) {
+        if (te.getStackInSlot(0) != null) {
+          // if there is stuff inside ...
+          if (!world.isRemote) te.dropSlot(0, 1, te.facing) // drop it
+        }
+        te.setInventorySlotContents(0, player.getCurrentEquippedItem.splitStack(1)) // insert the disk
+      } else {
+        if (!world.isRemote) {
+          player.openGui(OpenComputers, GuiType.DiskDrive.id, world, x, y, z)
+        }
       }
       true
+    } else {
+      if (te.getStackInSlot(0) != null) {
+        if (!world.isRemote) te.dropSlot(0, 1, te.facing)
+        true
+      }
+      else false
     }
-    else false
   }
 }


### PR DESCRIPTION
Disk drives now react to right clicks in the following ways:
regular right click, holding a disk: insert disk. If there is already a disk inside it is ejected first
regular right click, otherwise: open GUI
shift right click: eject disk

Furthermore, added myself to robot list
