### PR TITLE
Fix some LuaJ bugs

### DIFF
--- a/src/main/java/org/luaj/vm3/LuaDouble.java
+++ b/src/main/java/org/luaj/vm3/LuaDouble.java
@@ -219,7 +219,7 @@ public class LuaDouble extends LuaNumber {
 	
 	// string comparison
 	public int strcmp( LuaString rhs )      { typerror("attempt to compare number with string"); return 0; }
-			
+	
 	public String tojstring() {
 		/*
 		if ( v == 0.0 ) { // never occurs in J2me 
@@ -227,14 +227,11 @@ public class LuaDouble extends LuaNumber {
 			return ( bits >> 63 == 0 ) ? "0" : "-0";
 		}
 		*/
-		long l = (long) v;
-		if ( l == v ) 
-			return Long.toString(l);
 		if ( Double.isNaN(v) )
 			return JSTR_NAN;
-		if ( Double.isInfinite(v) ) 
+		if ( Double.isInfinite(v) )
 			return (v<0? JSTR_NEGINF: JSTR_POSINF);
-		return Float.toString((float)v);
+		return Double.toString(v);
 	}
 	
 	public LuaString strvalue() {

--- a/src/main/java/org/luaj/vm3/LuaString.java
+++ b/src/main/java/org/luaj/vm3/LuaString.java
@@ -27,6 +27,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.Arrays;
 
 import org.luaj.vm3.lib.MathLib;
 import org.luaj.vm3.lib.StringLib;

--- a/src/main/java/org/luaj/vm3/LuaString.java
+++ b/src/main/java/org/luaj/vm3/LuaString.java
@@ -394,7 +394,7 @@ public class LuaString extends LuaValue {
 	 * beginIndex and extending for (endIndex - beginIndex ) characters.
 	 */
 	public LuaString substring( int beginIndex, int endIndex ) {
-		return valueOf( m_bytes, m_offset + beginIndex, endIndex - beginIndex );
+		return new LuaString(Arrays.copyOfRange(m_bytes, beginIndex, endIndex), 0, endIndex - beginIndex);
 	}
 	
 	public int hashCode() {
@@ -704,8 +704,8 @@ public class LuaString extends LuaValue {
 		if ( i>=j )
 			return Double.NaN;
 		if ( m_bytes[i]=='0' && i+1<j && (m_bytes[i+1]=='x'||m_bytes[i+1]=='X'))
-			return scanlong(16, i+2, j);
-		double l = scanlong(10, i, j);
+			return scandouble(16, i+2, j);
+		double l = scandouble(10, i, j);
 		return Double.isNaN(l)? scandouble(i,j): l;
 	}
 	
@@ -722,25 +722,25 @@ public class LuaString extends LuaValue {
 		while ( i<j && m_bytes[j-1]==' ' ) --j;
 		if ( i>=j )
 			return Double.NaN;
-		return scanlong( base, i, j );
+		return scandouble( base, i, j );
 	}
 	
 	/**
-	 * Scan and convert a long value, or return Double.NaN if not found.
+	 * Scan and convert a double value, or return Double.NaN if not found.
 	 * @param base the base to use, such as 10
 	 * @param start the index to start searching from
 	 * @param end the first index beyond the search range
 	 * @return double value if conversion is valid, 
 	 * or Double.NaN if not
 	 */
-	private double scanlong( int base, int start, int end ) {
-		long x = 0;
+	private double scandouble( int base, int start, int end ) {
+		double x = 0;
 		boolean neg = (m_bytes[start] == '-');
 		for ( int i=(neg?start+1:start); i<end; i++ ) {
 			int digit = m_bytes[i] - (base<=10||(m_bytes[i]>='0'&&m_bytes[i]<='9')? '0':
 					m_bytes[i]>='A'&&m_bytes[i]<='Z'? ('A'-10): ('a'-10));
-			if ( digit < 0 || digit >= base )
-				return Double.NaN;		
+			if ( digit < 0 || digit >= base || (m_bytes[i] >= '9' && digit < 10))
+				return Double.NaN;
 			x = x * base + digit;
 			if ( x < 0 )
 				return Double.NaN; // overflow


### PR DESCRIPTION
LuaDouble:
Do not try Long.toString
Do not cast to float

LuaString:
Do not scan as a long
Add another check in scandouble (was scanlong)
Have substring create new bytes to work with
