### PR TITLE
Make io.read() support support not breaking

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/02_io.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/02_io.lua
@@ -21,8 +21,8 @@ end
 stdoutStream.close = stdinStream.close
 stderrStream.close = stdinStream.close
 
-function stdinStream:read(n, dowrap)
-  local result = term.read(stdinHistory, dowrap)
+function stdinStream:read(n, dobreak)
+  local result = term.read(stdinHistory, dobreak)
   while #stdinHistory > 10 do
     table.remove(stdinHistory, 1)
   end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/02_io.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/02_io.lua
@@ -21,8 +21,8 @@ end
 stdoutStream.close = stdinStream.close
 stderrStream.close = stdinStream.close
 
-function stdinStream:read(n)
-  local result = term.read(stdinHistory)
+function stdinStream:read(n, dowrap)
+  local result = term.read(stdinHistory, dowrap)
   while #stdinHistory > 10 do
     table.remove(stdinHistory, 1)
   end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -80,7 +80,7 @@ function term.isAvailable()
   return component.isAvailable("gpu") and component.isAvailable("screen")
 end
 
-function term.read(history)
+function term.read(history, dobreak)
   checkArg(1, history, "table", "nil")
   history = history or {}
   table.insert(history, "")
@@ -286,7 +286,7 @@ function term.read(history)
       table.remove(history)
     end
     term.setCursorBlink(false)
-    if term.getCursor() > 1 then
+    if term.getCursor() > 1 and dobreak ~= false then
       print()
     end
   end


### PR DESCRIPTION
If false is passed as second param to io.read() it now will
not perform a line break after hitting return
