### PR TITLE
Fix math.random

### DIFF
--- a/src/main/java/org/luaj/vm3/lib/MathLib.java
+++ b/src/main/java/org/luaj/vm3/lib/MathLib.java
@@ -211,15 +211,15 @@ public class MathLib extends TwoArgFunction {
 			return valueOf( random.nextDouble() );
 		}
 		public LuaValue call(LuaValue a) {
-			int m = a.checkint();
+			long m = a.checklong();
 			if (m<1) argerror(1, "interval is empty");
-			return valueOf( 1 + random.nextInt(m) );
+			return valueOf( (long)(random.nextDouble() * m) + 1L );
 		}
 		public LuaValue call(LuaValue a, LuaValue b) {
-			int m = a.checkint();
-			int n = b.checkint();
+			long m = a.checklong();
+			long n = b.checklong();
 			if (n<m) argerror(2, "interval is empty");
-			return valueOf( m + random.nextInt(n+1-m) );
+			return valueOf( (long)(random.nextDouble() * (n - m + 1)) + m );
 		}
 		
 	}

--- a/src/main/java/org/luaj/vm3/lib/MathLib.java
+++ b/src/main/java/org/luaj/vm3/lib/MathLib.java
@@ -211,15 +211,15 @@ public class MathLib extends TwoArgFunction {
 			return valueOf( random.nextDouble() );
 		}
 		public LuaValue call(LuaValue a) {
-			long m = a.checklong();
+			double m = a.checkdouble();
 			if (m<1) argerror(1, "interval is empty");
-			return valueOf( (long)(random.nextDouble() * m) + 1L );
+			return valueOf( Math.floor(random.nextDouble() * m) + 1L );
 		}
 		public LuaValue call(LuaValue a, LuaValue b) {
-			long m = a.checklong();
-			long n = b.checklong();
+			double m = a.checkdouble();
+			double n = b.checkdouble();
 			if (n<m) argerror(2, "interval is empty");
-			return valueOf( (long)(random.nextDouble() * (n - m + 1)) + m );
+			return valueOf( Math.floor(random.nextDouble() * (n - m + 1)) + m );
 		}
 		
 	}


### PR DESCRIPTION
Why I feel this is now correct:
Lua simply grabs a number, not of a specific type like int or double. However you can store ints inside a double so checkdouble is used instead.
However there is no nextDouble(double) method, so it has to be simulated via multiplication (what lua does anyway)
The fact that the variables are also double now is no concern, since in lua doing math.random(1,3.1), 4 can also show up.

Also, said problem is present in LuaStateFactory.scala and an issue will be created for it.
