### PR TITLE
Changing shell.parse so it can handle abit more

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/shell.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/shell.lua
@@ -163,33 +163,53 @@ function shell.execute(command, env, ...)
 end
 
 function shell.parse(...)
-  local params = table.pack(...)
-  local args = {}
+  local tmp = table.pack ( ... )
+  local args = ''
+
+	local arguments = {}
   local options = {}
-  local doneWithOptions = false
-  for i = 1, params.n do
-    local param = params[i]
-    if not doneWithOptions and type(param) == "string" then
-      if param == "--" then
-        doneWithOptions = true -- stop processing options at `--`
-      elseif unicode.sub(param, 1, 2) == "--" then
-        if param:match("%-%-(.-)=") ~= nil then
-          options[param:match("%-%-(.-)=")] = param:match("=(.*)")
-        else
-          options[unicode.sub(param, 3)] = true
-        end
-      elseif unicode.sub(param, 1, 1) == "-" and param ~= "-" then
-        for j = 2, unicode.len(param) do
-          options[unicode.sub(param, j, j)] = true
-        end
-      else
-        table.insert(args, param)
-      end
-    else
-      table.insert(args, param)
+
+  for _,l in pairs (tmp) do
+    if type(l) == 'string' then
+      args = args .. ' ' .. l
+     end
+  end
+  tmp = nil
+
+  for all, option, value in args:gmatch ('( %-([^ ]+) ?%"([^%"]*)")') do
+    if value == '' then value = true end
+    options [option] = value
+
+    args = unicode.sub ( args, 1, args:find(all,1,true) ) .. unicode.sub ( args, ({args:find(all,1,true)})[1] + all:len() )
+  end
+
+  for all, option, value in args:gmatch ( '( %-([^ ]) ?([0-9]*)) ' ) do
+    if value == '' then value = true end
+    options [option] = value
+
+    args = unicode.sub ( args, 1, ({args:find(all,1,true)})[1]) .. unicode.sub ( args, ({args:find(all,1,true)})[1] + all:len() )
+  end
+
+  for all, option, value in args:gmatch ( '( %-([^ ]+) ?([0-9]*)) ' ) do
+    if value == '' then value = true end
+    options [option] = value
+
+    args = unicode.sub ( args, 1, ({args:find(all,1,true)})[1]) .. unicode.sub ( args, ({args:find(all,1,true)})[1] + all:len() )
+  end
+
+  for all, option in args:gmatch ( '( %-([^ ]+)) ') do
+    options [option] = true
+
+    args = unicode.sub ( args, 1, args:find(all,1,true) ) .. unicode.sub ( args, ({args:find(all,1,true)})[1] + all:len() )
+  end
+
+  for word in args:gmatch ( '[^ ]*' ) do
+    if word ~= '' and word ~= ' ' then
+      table.insert ( arguments, word )
     end
   end
-  return args, options
+  
+  return arguments, options
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Making it possible for

./wierd -x1 -y 2 -z 4 -write "wooh" -l yah!
returns
{"yah!"},{z=4,y=2,x=1,write="wooh",l=true}

./wierd -write"wooh"
returns
{},{write="wooh"}

./wierd -write"ya -d"
returns
{},{write="ya -d"}

./wierd -write"asd
returns
{},{write"asd=true}

./wierd foo -write"hello" bar
returns
{"foo","bar"}, {write="hello"}

While i havn't super tested it with openOS, it can boot, mv -f respects it atleast, edit [file] works.
and while im not certainly sure why, it appears thats that shell.parse () gets a table thrown at it somewhere at boot?, while the original parse perverse it, i throw it away. OS seems fine without it, though if it is important, its easily added.

editted title
