### PR TITLE
Make init.lua do exact component matching

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/init.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/init.lua
@@ -24,7 +24,7 @@ do
   end
 
   -- Report boot progress if possible.
-  local gpu = component.list("gpu")()
+  local gpu = component.list("gpu", true)()
   local w, h
   if gpu and screen then
     component.invoke(gpu, "bind", screen)


### PR DESCRIPTION
Fixes init.lua randomly picking a different component that may happen to share "gpu" in the name.
