### PR TITLE
Added rc scripts system

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/rc.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/rc.lua
@@ -1,0 +1,9 @@
+local rc = require('rc')
+
+local args = {...}
+
+local res, reason = rc.runCommand(table.unpack(args))
+
+if reason then
+  print(reason)
+end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/etc/rc.cfg
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/etc/rc.cfg
@@ -1,0 +1,3 @@
+enabled = {}
+
+example = "Hello World!"

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/etc/rc.d/example.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/etc/rc.d/example.lua
@@ -1,0 +1,13 @@
+local count = 0
+
+function start(msg)
+  print("This script displays a welcome message and counts the number " ..
+  "of times it has been called. The welcome message can be set in the " ..
+  "config file /etc/rc.cfg")
+  print(args)
+  if msg then
+    print(msg)
+  end
+  print(count)
+  count = count +1
+end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/init.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/init.lua
@@ -150,6 +150,8 @@ do
   os.sleep(0.5) -- Allow signal processing by libraries.
   computer.pushSignal("init") -- so libs know components are initialized.
 
+  require('rc').allRunCommand('start') -- run all enabled rc scripts
+
   status("Starting shell...")
   require("term").clear()
   os.sleep(0.1) -- Allow init processing.

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/rc.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/rc.lua
@@ -1,0 +1,70 @@
+local fs = require('filesystem')
+
+local function loadConfig()
+  local env = {}
+  local fun, reason = loadfile('/etc/rc.cfg', 't', env)
+  if fun then
+    local res, reason = fun()
+    if true then
+      return env
+    else
+      return nil, reason
+    end
+  else
+    return nil, reason
+  end
+end
+
+local loaded = {}
+
+local function load(name, args)
+  if loaded[name] then
+    return loaded[name]
+  end
+  local fileName = fs.concat('/etc/rc.d/', name ..'.lua')
+  local env = setmetatable({args=args}, {__index = _G})
+  local fun, reason = loadfile(fileName, 't', env)
+  if fun then
+    local res, reason = fun()
+    loaded[name] = env
+    return env
+  else
+    return nil, reason
+  end
+end
+
+local function unload(name)
+  loaded[name] = nil
+end
+
+local function rawRunCommand(name, cmd, args, ...)
+  local env, reason = load(name, args)
+  if not env then
+    return nil, reason
+  end
+  if env[cmd] then
+    return env[cmd](...)
+  else
+    return nil, "Command '" .. cmd .. "' not found in daemon '" .. name .. "'"
+  end
+end
+
+local function runCommand(name, cmd, ...)
+  local conf, reason = loadConfig()
+  if not conf then
+    return nil, reason
+  end
+  local args = conf[name]
+  return rawRunCommand(name, cmd, args, ...)
+end
+
+local function allRunCommand(cmd, ...)
+  local conf = loadConfig()
+  local res = {}
+  for i, name in ipairs(conf.enable) do
+    res[name] = {rawRunCommand(name, cmd, conf[name], ...)}
+  end
+  return res
+end
+
+return {load = load, unload = unload, loadConfig = loadConfig, runCommand = runCommand, allRunCommand=allRunCommand}


### PR DESCRIPTION
Here is a small system that allows user to more easily manage and install daemons and libraries. There is also an example script that doesn't really do anything. To enable it at startup, at it to the `enabled` table. 
