### PR TITLE
Fixed recipes for StargateTech2

### DIFF
--- a/src/main/resources/assets/opencomputers/recipes/default.recipes
+++ b/src/main/resources/assets/opencomputers/recipes/default.recipes
@@ -84,7 +84,7 @@ openOS {
 }
 
 abstractBusCard {
-  input: [[{block="StargateTech2:busCable"}, {item="StargateTech2:naquadah", subID=3}, ""]
+  input: [[{block="StargateTech2:block.busCable"}, {item="StargateTech2:naquadah", subID=3}, ""]
           ["", "oc:materialCard", ""]]
 }
 graphicsCard1 {

--- a/src/main/resources/assets/opencomputers/recipes/hardmode.recipes
+++ b/src/main/resources/assets/opencomputers/recipes/hardmode.recipes
@@ -77,7 +77,7 @@ hdd3 {
 }
 
 abstractBusCard {
-  input: [[busCable, {item=naquadah, subID=8}, ""]
+  input: [[{block="StargateTech2:block.busCable"}, {item="StargateTech2:naquadah", subID=3}, ""]
           ["", "oc:materialCard", ""]]
 }
 graphicsCard1 {


### PR DESCRIPTION
The recipes were broken for new SGT2 builds causing the cards to disappear from game.
