### PR TITLE
Minor bug in flash.lua

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/flash.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/flash.lua
@@ -51,6 +51,7 @@ local function writeRom()
       local response = io.read()
     until response and response:lower():sub(1, 1) == "y"
     io.write("Beginning to flash EEPROM.\n")
+    eeprom = component.eeprom
   end
 
   if not options.q then


### PR DESCRIPTION
Fixed eeprom reference in flash.lua

We asked the users to swap the eeprom out here. If they did, the reference to eeprom is invalid and must be redefined. Using `component.eeprom` directly would work, but the following lines reference `eeprom` which, as requested, should have been swapped, and now references an invalid eeprom, causing an error.

This closes #796 
