### PR TITLE
Fix issues with locale/tonumber() on some machines

### DIFF
--- a/src/main/resources/assets/opencomputers/lua/machine.lua
+++ b/src/main/resources/assets/opencomputers/lua/machine.lua
@@ -1,3 +1,4 @@
+os.setlocale("C")
 local hookInterval = 100
 local deadline = math.huge
 local hitDeadline = false

--- a/src/main/scala/li/cil/oc/util/LuaStateFactory.scala
+++ b/src/main/scala/li/cil/oc/util/LuaStateFactory.scala
@@ -229,8 +229,7 @@ object LuaStateFactory {
         state.pop(8)
 
         // Prepare table for os stuff.
-        state.newTable()
-        state.setGlobal("os")
+        state.openLib(jnlua.LuaState.Library.OS)
 
         // Kill compat entries.
         state.pushNil()


### PR DESCRIPTION
This fixes tonumber("1.2") not working but tonumber("1,2") working.
