### PR TITLE
Fix build.gradle for Gradle 2.x, copy over assets automatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,9 +175,9 @@ dependencies {
     embedded files('libs/OpenComputers-JNLua.jar', 'libs/OpenComputers-LuaJ.jar')
 }
 
-idea.module.scopes.PROVIDED.plus += configurations.provided
+idea.module.scopes.PROVIDED.plus += [configurations.provided]
 // TODO Causes errors on Gradle 2 for me (No such property: allDependencies for class: java.io.File).
-//eclipse.classpath.plusConfigurations += configurations.provided
+//eclipse.classpath.plusConfigurations += [configurations.provided]
 
 minecraft {
     version = "${config.minecraft.version}-${config.forge.version}"
@@ -276,5 +276,12 @@ publishing {
         maven {
             url "${config.maven.url}"
         }
+    }
+}
+
+// this is needed for IntelliJ so we don't have to copy over the assets manually every time
+sourceSets {
+    main {
+        output.resourcesDir = output.classesDir
     }
 }


### PR DESCRIPTION
`idea.module.scopes.PROVIDED.plus += configurations.provided` is no longer valid since Groovy 1.8.9, the "object" you want to add has to be a collection too.
Also, let Gradle automatically copy the assets (from build/resources/main to build/classes/main) so we don't have to do that manually anymore.
