### PR TITLE
Add Botania integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,10 @@ repositories {
         name 'immibis'
         artifactPattern "https://dl.dropboxusercontent.com/u/2944265/mods/autobuilt/files/[module]-[revision].[ext]"
     }
+    ivy {
+        name 'Botania'
+        artifactPattern "http://vazkii.us/mod/[module]/files/deobf/[module] [revision]-deobf.[ext]"
+    }
 
     ivy {
         name 'CoFHLib'
@@ -174,6 +178,7 @@ dependencies {
     provided name: 'EnderIO', version: config.eio.version, ext: 'jar'
     provided name: 'Railcraft', version: config.rc.version, ext: 'jar'
     provided name: 'BloodMagic', version: config.bloodmagic.version, ext: 'jar'
+    provided name: 'Botania', version: config.botania.version, ext: 'jar'
 
     compile 'com.google.code.findbugs:jsr305:1.3.9' // Annotations used by google libs.
 

--- a/build.properties
+++ b/build.properties
@@ -3,6 +3,7 @@ forge.version=10.13.2.1236
 
 oc.version=1.4.4a
 oc.subversion=dev
+
 ae2.version=rv1-stable-1
 bc.version=6.2.6
 botania.version=r1.3-151

--- a/build.properties
+++ b/build.properties
@@ -3,9 +3,9 @@ forge.version=10.13.2.1236
 
 oc.version=1.4.4a
 oc.subversion=dev
-
 ae2.version=rv1-stable-1
 bc.version=6.2.6
+botania.version=r1.3-151
 bloodmagic.cf=2223/203
 bloodmagic.version=1.3.0a-1
 cc.cf=2216/236

--- a/src/main/scala/li/cil/oc/integration/Mods.scala
+++ b/src/main/scala/li/cil/oc/integration/Mods.scala
@@ -21,6 +21,7 @@ object Mods {
 
   val AppliedEnergistics2 = new SimpleMod(IDs.AppliedEnergistics2, version = "@[rv1,)", providesPower = true)
   val BattleGear2 = new SimpleMod(IDs.BattleGear2)
+  val Botania = new SimpleMod(IDs.Botania)
   val BloodMagic = new SimpleMod(IDs.BloodMagic)
   val BuildCraft = new SimpleMod(IDs.BuildCraft)
   val BuildCraftTiles = new SimpleMod(IDs.BuildCraftTiles)
@@ -73,6 +74,7 @@ object Mods {
 
   val Proxies = Array(
     integration.appeng.ModAppEng,
+    integration.botania.ModBotania,
     integration.bloodmagic.ModBloodMagic,
     integration.buildcraft.tools.ModBuildCraftAPITools,
     integration.buildcraft.tiles.ModBuildCraftAPITiles,
@@ -100,6 +102,7 @@ object Mods {
     integration.waila.ModWaila,
     integration.wrcbe.ModWRCBE,
     integration.wrsve.ModWRSVE,
+    integration.bloodmagic.ModBloodMagic,
 
     // Register the general IPeripheral driver last, if at all, to avoid it
     // being used rather than other more concrete implementations.
@@ -133,6 +136,7 @@ object Mods {
   object IDs {
     final val AppliedEnergistics2 = "appliedenergistics2"
     final val BattleGear2 = "battlegear2"
+    final val Botania = "Botania"
     final val BloodMagic = "AWWayofTime"
     final val BuildCraft = "BuildCraft|Core"
     final val BuildCraftPower = "BuildCraftAPI|power"

--- a/src/main/scala/li/cil/oc/integration/Mods.scala
+++ b/src/main/scala/li/cil/oc/integration/Mods.scala
@@ -102,7 +102,6 @@ object Mods {
     integration.waila.ModWaila,
     integration.wrcbe.ModWRCBE,
     integration.wrsve.ModWRSVE,
-    integration.bloodmagic.ModBloodMagic,
 
     // Register the general IPeripheral driver last, if at all, to avoid it
     // being used rather than other more concrete implementations.

--- a/src/main/scala/li/cil/oc/integration/botania/ConverterManaItem.java
+++ b/src/main/scala/li/cil/oc/integration/botania/ConverterManaItem.java
@@ -1,0 +1,23 @@
+package li.cil.oc.integration.botania;
+
+import li.cil.oc.api.driver.Converter;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import vazkii.botania.api.mana.IManaItem;
+
+import java.util.Map;
+
+public class ConverterManaItem implements Converter {
+    @Override
+    public void convert(Object value, Map<Object, Object> output) {
+        if (value instanceof ItemStack) {
+            final ItemStack stack = (ItemStack) value;
+            final Item item = stack.getItem();
+            if (item instanceof IManaItem) {
+                final IManaItem manaItem = (IManaItem) item;
+                output.put("mana", manaItem.getMana(stack));
+                output.put("maxMana", manaItem.getMaxMana(stack));
+            }
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/botania/DriverAltar.java
+++ b/src/main/scala/li/cil/oc/integration/botania/DriverAltar.java
@@ -1,0 +1,49 @@
+package li.cil.oc.integration.botania;
+
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import li.cil.oc.integration.ManagedTileEntityEnvironment;
+import net.minecraft.world.World;
+import vazkii.botania.common.block.tile.TileAltar;
+
+public class DriverAltar extends DriverTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return TileAltar.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, int x, int y, int z) {
+        return new Environment((TileAltar) world.getTileEntity(x, y, z));
+    }
+
+    public static class Environment extends ManagedTileEntityEnvironment<TileAltar> implements NamedBlock {
+        public Environment(TileAltar tileEntity) {
+            super(tileEntity, "petal_apothecary");
+        }
+
+        @Override
+        public String preferredName() {
+            return "petal_apothecary";
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Callback(doc = "function():boolean -- Returns whether the apothecary contains a liquid.")
+        public Object[] hasLiquid(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.hasWater() || tileEntity.hasLava()};
+        }
+
+        @Callback(doc = "function():boolean -- Returns whether the apothecary is mossy.")
+        public Object[] isMossy(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.isMossy};
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/botania/DriverManaBlock.java
+++ b/src/main/scala/li/cil/oc/integration/botania/DriverManaBlock.java
@@ -1,0 +1,44 @@
+package li.cil.oc.integration.botania;
+
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import li.cil.oc.integration.ManagedTileEntityEnvironment;
+import net.minecraft.world.World;
+import vazkii.botania.api.mana.IManaBlock;
+
+public class DriverManaBlock extends DriverTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return IManaBlock.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, int x, int y, int z) {
+        return new Environment((IManaBlock) world.getTileEntity(x, y, z));
+    }
+
+    public static class Environment extends ManagedTileEntityEnvironment<IManaBlock> implements NamedBlock {
+        public Environment(IManaBlock tileEntity) {
+            super(tileEntity, "mana_block");
+        }
+
+        @Override
+        public String preferredName() {
+            return "mana_block";
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Callback(doc = "function():number -- Get the amount of mana this mana pool contains.")
+        public Object[] getCurrentMana(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.getCurrentMana()};
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/botania/DriverManaPool.java
+++ b/src/main/scala/li/cil/oc/integration/botania/DriverManaPool.java
@@ -1,0 +1,44 @@
+package li.cil.oc.integration.botania;
+
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import li.cil.oc.integration.ManagedTileEntityEnvironment;
+import net.minecraft.world.World;
+import vazkii.botania.api.mana.IManaPool;
+
+public class DriverManaPool extends DriverTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return IManaPool.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, int x, int y, int z) {
+        return new Environment((IManaPool) world.getTileEntity(x, y, z));
+    }
+
+    public static class Environment extends ManagedTileEntityEnvironment<IManaPool> implements NamedBlock {
+        public Environment(IManaPool tileEntity) {
+            super(tileEntity, "mana_pool");
+        }
+
+        @Override
+        public String preferredName() {
+            return "mana_pool";
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Callback(doc = "function():boolean -- Get whether the mana pool is currently outputting power.")
+        public Object[] isOutputtingPower(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.isOutputtingPower()};
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/botania/DriverManaReceiver.java
+++ b/src/main/scala/li/cil/oc/integration/botania/DriverManaReceiver.java
@@ -1,0 +1,49 @@
+package li.cil.oc.integration.botania;
+
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import li.cil.oc.integration.ManagedTileEntityEnvironment;
+import net.minecraft.world.World;
+import vazkii.botania.api.mana.IManaReceiver;
+
+public class DriverManaReceiver extends DriverTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return IManaReceiver.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, int x, int y, int z) {
+        return new Environment((IManaReceiver) world.getTileEntity(x, y, z));
+    }
+
+    public static class Environment extends ManagedTileEntityEnvironment<IManaReceiver> implements NamedBlock {
+        public Environment(IManaReceiver tileEntity) {
+            super(tileEntity, "mana_receiver");
+        }
+
+        @Override
+        public String preferredName() {
+            return "mana_receiver";
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Callback(doc = "function():boolean -- Get whether the mana pool is currently full.")
+        public Object[] isFull(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.isFull()};
+        }
+
+        @Callback(doc = "function():boolean -- Get whether the mana pool can currently receive mana from bursts.")
+        public Object[] canReceiveManaFromBursts(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.canRecieveManaFromBursts()};
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/botania/DriverManaSpreader.java
+++ b/src/main/scala/li/cil/oc/integration/botania/DriverManaSpreader.java
@@ -1,0 +1,54 @@
+package li.cil.oc.integration.botania;
+
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import li.cil.oc.integration.ManagedTileEntityEnvironment;
+import net.minecraft.world.World;
+import vazkii.botania.common.block.tile.mana.TileSpreader;
+
+public class DriverManaSpreader extends DriverTileEntity {
+    @Override
+    public Class<?> getTileEntityClass() {
+        return TileSpreader.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, int x, int y, int z) {
+        return new Environment((TileSpreader) world.getTileEntity(x, y, z));
+    }
+
+    public static class Environment extends ManagedTileEntityEnvironment<TileSpreader> implements NamedBlock {
+        public Environment(TileSpreader tileEntity) {
+            super(tileEntity, "mana_spreader");
+        }
+
+        @Override
+        public String preferredName() {
+            return "mana_spreader";
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Callback(doc = "function():boolean -- Get whether this spreader is a redstone mana spreader.")
+        public Object[] isRedstone(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.isRedstone()};
+        }
+
+        @Callback(doc = "function():boolean -- Get whether this spreader is an elven mana spreader.")
+        public Object[] isElven(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.isDreamwood() && !tileEntity.isULTRA_SPREADER()};
+        }
+
+        @Callback(doc = "function():boolean -- Get whether this spreader is a gaia mana spreader.")
+        public Object[] isGaia(final Context context, final Arguments arguments) {
+            return new Object[]{tileEntity.isULTRA_SPREADER()};
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/botania/ModBotania.scala
+++ b/src/main/scala/li/cil/oc/integration/botania/ModBotania.scala
@@ -1,0 +1,18 @@
+package li.cil.oc.integration.botania
+
+import li.cil.oc.api.Driver
+import li.cil.oc.integration.{Mods, ModProxy}
+
+object ModBotania extends ModProxy {
+  override def getMod = Mods.Botania
+
+  override def initialize() {
+    Driver.add(new DriverManaBlock)
+    Driver.add(new DriverManaReceiver)
+    Driver.add(new DriverManaPool)
+    Driver.add(new DriverManaSpreader)
+    Driver.add(new DriverAltar)
+
+    Driver.add(new ConverterManaItem)
+  }
+}


### PR DESCRIPTION
Currently supports mana items (such as Mana Tablets), most mana blocks (for example Mana Pools and Spreaders) and the Petal Apothecary.
