### PR TITLE
Fixed filesystem.list returning a list with duplicate values

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/filesystem.lua
@@ -351,8 +351,8 @@ function filesystem.list(path)
       table.remove(result, i)
     else
       f = result[i]
+      i = i + 1
     end
-    i = i + 1
   end
   local i = 0
   return function()


### PR DESCRIPTION
The error was caused by increasing the index i after removing its value: The value after the removed one was ignored.
To see an effect you need two directories being neighbors in the list.
Both also have to have a symbolic link or a mounting point inside.
-> That's a rare but possible combination.

Here an example:
-bugdir/
--a/
---link1 -> link somewhere
--b/
---link2 -> link somewhere
# ls bugdir

a  b  b (!)
