### PR TITLE
Make the Sides API more idiomatic

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/sides.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/sides.lua
@@ -32,6 +32,31 @@ local sides = {
   forward = 3
 }
 
+local metatable = getmetatable(sides) or {}
+
+-- sides[0..5] are mapped to itertable[1..6].
+local itertable = {
+  sides[0],
+  sides[1],
+  sides[2],
+  sides[3],
+  sides[4],
+  sides[5]
+}
+
+-- Future-proofing against the possible introduction of additional
+-- logical sides (e.g. [7] = "all", [8] = "none", etc.).
+function metatable.__len(sides)
+  return #itertable
+end
+
+-- Allow `sides` to be iterated over like a normal (1-based) array.
+function metatable.__ipairs(sides)
+  return ipairs(itertable)
+end
+
+setmetatable(sides, metatable)
+
 -------------------------------------------------------------------------------
 
 return sides


### PR DESCRIPTION
Because the Sides API directly maps directly to the `ForgeDirection` enum (which is 0-based to match Minecraft's internal side numbering), it does not behave as expected for a Lua array (which are typically 1-based), despite presenting like one.

This causes problems when trying to use the Sides API as an array.  The most clear example of this<sup>1</sup> is the `ipairs` function — currently, they interact as follows:

```
lua> for _, side in ipairs(require("sides")) do print(side) end
top
back
front
right
left
unknown
```

Obviously, this is a quite surprising result!  The proposed change adds a metatable to the Sides API which overrides the default `ipairs` behavior to iterate over the six "normal" sides.  (It also overrides the `#` operator, as it is currently only correct by coincidence — it counts "unknown", but not "bottom".)

<sup>1</sup> For completeness, the real-world use case which exposed this problem, scanning for inventories:

```
lua> for _, side in ipairs(sides) do print(inventory_controller.getInventorySize(sides[side])) end
1
nil     no inventory
nil     no inventory
nil     no inventory
nil     no inventory
Invalid side
stack traceback:
    <...>
```
