### PR TITLE
Create yes.lua

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/yes.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/yes.lua
@@ -1,0 +1,43 @@
+--[[Lua implementation of the UN*X yes command--]]
+local shell = require("shell")
+
+local args, options = shell.parse(...)
+
+-- Version option as in GNU coreutils, but in ther case it is "--version"
+if options.V then
+  io.write("yes v:1.0-2\n")
+  io.write("Inspired by functionality of yes from GNU coreutils\n")
+  return 0
+end
+-- Help option as in GNU coreutils, but in ther case it is "--help"
+if options.h then
+  io.write("Usage: yes [string]...\n")
+  io.write("OR:    yes [-V/h]\n")
+  io.write("\n")
+  io.write("yes prints the command line arguments, or 'y', until is killed.\n")
+  io.write("\n")
+  io.write("Options:\n")
+  io.write("	-V	Version\n")
+  io.write("	-h	This help\n")
+  return 0
+end
+
+-- If there are no arguments, print 'y' and new line, if there is print it.
+if #args == 0 then
+  while ( true )
+  do
+    io.write("y\n")
+    os.sleep(0)
+  end
+else
+  while ( true )
+  do
+    for i=1, #args, 1
+    do
+      io.write(args[i], " ")
+    end
+    io.write("\n")
+    os.sleep(0)
+  end
+end
+return 0

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/yes.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/yes.lua
@@ -3,22 +3,21 @@ local shell = require("shell")
 
 local args, options = shell.parse(...)
 
--- Version option as in GNU coreutils, but in ther case it is "--version"
-if options.V then
+if options.V or options.version then
   io.write("yes v:1.0-2\n")
   io.write("Inspired by functionality of yes from GNU coreutils\n")
   return 0
 end
--- Help option as in GNU coreutils, but in ther case it is "--help"
-if options.h then
+
+if options.h or options.help then
   io.write("Usage: yes [string]...\n")
   io.write("OR:    yes [-V/h]\n")
   io.write("\n")
   io.write("yes prints the command line arguments, or 'y', until is killed.\n")
   io.write("\n")
   io.write("Options:\n")
-  io.write("	-V	Version\n")
-  io.write("	-h	This help\n")
+  io.write("	-V, --version	Version\n")
+  io.write("	-h, --help  	This help\n")
   return 0
 end
 


### PR DESCRIPTION
Lua implementation of functionality provided by yes command from GNU coreutils (in Linux). However it doesn't use any of GNU code, so it is not forcing GPLv3+ license.

It has full functionality but options had to been changed to single letter (like -h instead of original --help in GNU). Main use case requires piping, but works without it.

I have also created man page, but I have to send it in different pull request (don't know how to do it in github webpage).

![yes](https://cloud.githubusercontent.com/assets/6283661/6044681/2de27d90-ac95-11e4-92d3-9bc925016547.png)
![yes man](https://cloud.githubusercontent.com/assets/6283661/6044682/2de436d0-ac95-11e4-89ce-9adfa0a2c3d7.png)
