### PR TITLE
Allow "flattened" converted values to be recursively converted

### DIFF
--- a/src/main/scala/li/cil/oc/server/driver/Registry.scala
+++ b/src/main/scala/li/cil/oc/server/driver/Registry.scala
@@ -146,11 +146,6 @@ private[oc] object Registry extends api.detail.DriverAPI {
           memo += arg -> null
           null
         }
-        else if (converted.size == 1 && converted.containsKey("oc:flatten")) {
-          val value = converted.get("oc:flatten")
-          memo += arg -> value // Update memoization map.
-          value
-        }
         else {
           // This is a little nasty but necessary because we need to keep the
           // 'converted' value up-to-date for any reference created to it in
@@ -163,7 +158,14 @@ private[oc] object Registry extends api.detail.DriverAPI {
           memo += converted -> converted // Makes convertMap re-use the map.
           convertRecursively(converted, memo, force = true)
           memo -= converted
-          converted
+          if (converted.size == 1 && converted.containsKey("oc:flatten")) {
+            val value = converted.get("oc:flatten")
+            memo += arg -> value // Update memoization map.
+            value
+          }
+          else {
+            converted
+          }
         }
     }
   }


### PR DESCRIPTION
Currently, converters which use the `oc:flatten` special key aren't given the benefit of recursive conversion.  In other words, the following code (for example) in a converter produces the "Tried to push an unsupported value" warning rather than a converted item stack.

```
output.put("oc:flatten", itemStack);
```

This change simply waits to flatten until _after_ recursive conversion has occurred.
