### PR TITLE
Add converters for World and WorldProvider objects

### DIFF
--- a/src/main/scala/li/cil/oc/integration/vanilla/ConverterWorld.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ConverterWorld.scala
@@ -1,0 +1,17 @@
+package li.cil.oc.integration.vanilla
+
+import java.util
+
+import li.cil.oc.api
+import net.minecraft.world
+
+import scala.collection.convert.WrapAsScala._
+
+object ConverterWorld extends api.driver.Converter {
+  override def convert(value: AnyRef, output: util.Map[AnyRef, AnyRef]) =
+    value match {
+      case world: world.World =>
+        output += "oc:flatten" -> world.provider
+      case _ =>
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/vanilla/ConverterWorldProvider.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ConverterWorldProvider.scala
@@ -1,6 +1,9 @@
 package li.cil.oc.integration.vanilla
 
+import java.nio.ByteBuffer
+import java.security.MessageDigest
 import java.util
+import java.util.UUID
 
 import li.cil.oc.api
 import net.minecraft.world
@@ -11,7 +14,12 @@ object ConverterWorldProvider extends api.driver.Converter {
   override def convert(value: AnyRef, output: util.Map[AnyRef, AnyRef]) =
     value match {
       case provider: world.WorldProvider =>
-        output += "id" -> Int.box(provider.dimensionId)
+        val digest = MessageDigest.getInstance("MD5")
+
+        digest.update(ByteBuffer.allocate(8).putLong(provider.getSeed).array)
+        digest.update(ByteBuffer.allocate(4).putInt(provider.dimensionId).array)
+
+        output += "id" -> UUID.nameUUIDFromBytes(digest.digest()).toString
         output += "name" -> provider.getDimensionName
       case _ =>
     }

--- a/src/main/scala/li/cil/oc/integration/vanilla/ConverterWorldProvider.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ConverterWorldProvider.scala
@@ -1,0 +1,18 @@
+package li.cil.oc.integration.vanilla
+
+import java.util
+
+import li.cil.oc.api
+import net.minecraft.world
+
+import scala.collection.convert.WrapAsScala._
+
+object ConverterWorldProvider extends api.driver.Converter {
+  override def convert(value: AnyRef, output: util.Map[AnyRef, AnyRef]) =
+    value match {
+      case provider: world.WorldProvider =>
+        output += "id" -> Int.box(provider.dimensionId)
+        output += "name" -> provider.getDimensionName
+      case _ =>
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/vanilla/ModVanilla.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ModVanilla.scala
@@ -32,5 +32,7 @@ object ModVanilla extends ModProxy {
     Driver.add(ConverterFluidTankInfo)
     Driver.add(ConverterItemStack)
     Driver.add(ConverterNBT)
+    Driver.add(ConverterWorld)
+    Driver.add(ConverterWorldProvider)
   }
 }


### PR DESCRIPTION
The rationale for dividing this into two converters is that a) it saves the effort of looking up a `World` reference when one already has a `WorldProvider` reference; and b) while the information is _actually_ contained within a `WorldProvider` object, it _logically_ belongs to a "world", which simply happens to be represented by multiple objects.

`id` is exposed so that worlds/dimensions can be correctly distinguished even if they happen to have the same name.  `name` is, of course, exposed for player-friendly display.

(Note also that this change is dependent on PR #897 in order to function correctly.)
