### PR TITLE
Added basic hostname mechanism to OpenOS

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/hostname.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/hostname.lua
@@ -1,14 +1,20 @@
 local args = {...}
 if args[1] then
-  local file = io.open("/etc/hostname", "w")
-  file:write(args[1])
-  file:close()
-  os.setenv("HOSTNAME", args[1])
-  os.setenv("PS1", "$HOSTNAME:$PWD# ")
+  local file, reason = io.open("/etc/hostname", "w")
+  if not file then
+    io.stderr:write(reason .. "\n")
+  else
+    file:write(args[1])
+    file:close()
+    os.setenv("HOSTNAME", args[1])
+    os.setenv("PS1", "$HOSTNAME:$PWD# ")
+  end
 else
   local file = io.open("/etc/hostname")
   if file then
-    io.write(file:read("*l"))
+    io.write(file:read("*l"), "\n")
     file:close()
+  else
+    io.stderr:write("Hostname not set\n")
   end
 end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/hostname.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/hostname.lua
@@ -1,0 +1,14 @@
+local args = {...}
+if args[1] then
+  local file = io.open("/etc/hostname", "w")
+  file:write(args[1])
+  file:close()
+  os.setenv("HOSTNAME", args[1])
+  os.setenv("PS1", "$HOSTNAME:$PWD# ")
+else
+  local file = io.open("/etc/hostname")
+  if file then
+    io.write(file:read("*l"))
+    file:close()
+  end
+end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/94_shell.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/94_shell.lua
@@ -14,3 +14,12 @@ shell.setAlias("view", "edit -r")
 shell.setAlias("help", "man")
 shell.setAlias("?", "man")
 shell.setAlias("cp", "cp -i")
+
+event.listen("init", function()
+  local file = io.open("/etc/hostname")
+  if file then
+    os.setenv("HOSTNAME", file:read("*l"))
+    os.setenv("PS1", "$HOSTNAME:$PWD# ")
+    file:close()
+  end
+end)

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/hostname
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/hostname
@@ -1,0 +1,12 @@
+NAME
+  hostname - Display and modify hostname
+
+SYNOPIS
+  hostname [NEW NAME]
+
+EXAMPLES
+  hostname
+    Prints currently set hostname
+
+  hostname test
+    Sets hostname of this computer to test


### PR DESCRIPTION
It gives some simple 'standard' way of naming machines, useful for networked applications. Also, the network floppy is compatibile with that.
