### PR TITLE
cat.lua now closes opened files properly

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/cat.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/cat.lua
@@ -21,5 +21,6 @@ else
         io.write(line)
       end
     until not line
+    file:close()
   end
 end


### PR DESCRIPTION
The title says everything.
It caused a lot of Out of Memory-Errors when I tested a custom file system. (-> many unclosed streams)
