### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 # Debugging
 /eclipse
 /run
+
+# OS X
+.DS_Store


### PR DESCRIPTION
This is so mac users like me can send pull requests without the .DS_Store file that are auto-generatored by OS-X, since most people don't like those. See: http://en.wikipedia.org/wiki/.DS_Store

(I'm surprised this hasn't be done yet)
