### PR TITLE
Added Baymax as a robot name.

### DIFF
--- a/src/main/resources/assets/opencomputers/robot.names
+++ b/src/main/resources/assets/opencomputers/robot.names
@@ -13,6 +13,7 @@ Anson Argyris      # Perry Rhodan
 ASIMO              # Honda
 Atlas              # Portal
 Augustus           # Perry Rhodan
+Baymax             # Big Hero 6
 Bender             # Futurama
 BMO                # Adventure Time
 BraitenBurg        # Simple intelligent agents.


### PR DESCRIPTION
Same as #1072 & #1071 but actually fixed this time.

I just love [Big Hero 6](https://en.wikipedia.org/wiki/Big_Hero_6_%28film%29) and thought Baymax would be a great robot name to add to OpenComputers.

**Edit**: Changed the Big Hero 6 link to the Wikipedia page as it provides more details about the film.
