### PR TITLE
Basic self-update program for OpenOS

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/install.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/install.lua
@@ -1,8 +1,54 @@
 local component = require("component")
 local computer = require("computer")
 local event = require("event")
-local unicode = require("unicode")
+local fs = require("filesystem")
 local shell = require("shell")
+local unicode = require("unicode")
+
+-- Modified version of recurse from /bin/cp.lua
+local function rcopy(fromPath, toPath, ignore)
+  ignore = ignore or {}
+  os.sleep(0) -- allow interrupting
+  if fs.isDirectory(fromPath) then
+    if fs.canonical(fromPath) == fs.canonical(fs.path(toPath)) then
+      return nil, "cannot copy a directory, `" .. fromPath .. "', into itself, `" .. toPath .. "'\n"
+    end
+    if fs.exists(toPath) and not fs.isDirectory(toPath) then
+      -- my real cp always does this, even with -f, -n or -i.
+      return nil, "cannot overwrite non-directory `" .. toPath .. "' with directory `" .. fromPath .. "'"
+    end
+    print(fromPath .. " -> " .. toPath)
+    fs.makeDirectory(toPath)
+    for file in fs.list(fromPath) do
+      local result, reason = rcopy(fs.concat(fromPath, file), fs.concat(toPath, file), ignore)
+      if not result then
+        return nil, reason
+      end
+    end
+    return true
+  else
+    if fs.exists(toPath) then
+      if fs.canonical(fromPath) == fs.canonical(toPath) then
+        return nil, "`" .. fromPath .. "' and `" .. toPath .. "' are the same file"
+      end
+      if fs.isDirectory(toPath) then
+        return nil, "cannot overwrite directory `" .. toPath .. "' with non-directory"
+      else
+        for n, part in ipairs(ignore) do
+          print("match ^" .. part .. " on " .. fs.canonical(toPath))
+          if fs.canonical(toPath):match("^" .. part) then
+            print("Skipping " .. fromPath .. " -> " .. toPath)
+            return true -- file is in ignored directory
+          end
+        end
+        -- else: default to overwriting
+      end
+      fs.remove(toPath)
+    end
+    print(fromPath .. " -> " .. toPath)
+    return fs.copy(fromPath, toPath)
+  end
+end
 
 local args, options = shell.parse(...)
 
@@ -47,12 +93,18 @@ end
 candidates = nil
 
 local name = options.name or "OpenOS"
-print("Installing " .. name .." to device " .. (choice.getLabel() or choice.address))
+print("Installing " .. name .. " to device " .. (choice.getLabel() or choice.address))
 os.sleep(0.25)
 local origin = options.from and options.from:sub(1,3) or computer.getBootAddress():sub(1, 3)
 local fromDir = options.fromDir or "/"
 local mnt = choice.address:sub(1, 3)
-local result, reason = os.execute("/bin/cp -vr /mnt/" .. origin .. fromDir .. "* /mnt/" .. mnt .. "/")
+
+local ignore = {}
+for part in string.gmatch(options.ignore, "[^:]+") do
+  table.insert(ignore, fs.canonical("/mnt/" .. mnt .. "/" .. part))
+end
+
+local result, reason = rcopy("/mnt/" .. origin .. fromDir, "/mnt/" .. mnt .. "/", ignore)
 if not result then
   error(reason, 0)
 end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/update.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/update.lua
@@ -1,0 +1,20 @@
+local component = require("component")
+local computer = require("computer")
+local args, options = shell.parse(...)
+local from = "--from="
+
+if not options.from then
+  for addr in component.list("filesystem") do
+    if addr ~= computer.getBootAddress() and component.proxy(addr).getLabel() == "openos" then
+      from = from .. addr
+      break
+    end
+  end
+  
+  if from == "--from=" then
+    print("Could not find an OpenOS boot device to update from.")
+    return
+  end
+end
+
+return os.execute("install " .. from .. " --ignore=/etc --noboot --nolabelset " .. table.concat(table.pack(...), " "))

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/update.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/update.lua
@@ -17,4 +17,4 @@ if not options.from then
   end
 end
 
-return os.execute("install " .. from .. " --ignore=/etc --noboot --nolabelset " .. table.concat(table.pack(...), " "))
+return os.execute("install " .. from .. " --update --noboot --nolabelset " .. table.concat(table.pack(...), " "))

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/install
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/install
@@ -1,0 +1,32 @@
+NAME
+  install - copy a directory tree onto a user-selected file system
+
+SYNOPSIS
+  install [OPTION]...
+
+DESCRIPTION
+  Copy a directory recursively from one filesystem onto the root of a user-selected destination filesystem. By default the source directory is the root of the boot filesystem, usually an OpenOS installation.
+
+OPTIONS
+  --from
+    address of the source filesystem, defaults to boot address
+  --fromDir
+    directory on the source filesystem to copy from, defaults to filesystem root
+  --ignore
+    colon-separated list of directories on the destination filesystem where existing files should not be overwritten
+  --name
+    new label for the destination filesystem, defaults to OpenOS
+  --noboot
+    do not prompt to set destination as default boot device
+  --nolabelset
+    do not label the destination filesystem (overrides --name)
+
+EXAMPLES
+  install
+    Install OpenOS from the boot filesystem, set the destination as the boot device and label it OpenOS.
+
+  install --from abc --fromDir programs/helloworld --noboot --nolabelset
+    Install the files at programs/helloworld on filesystem address abc, without changing the boot device or label.
+
+  install --from 562 --ignore /etc
+    Install all files from filesystem address 562, without overwriting any files in /etc at the destination.

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/install
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/install
@@ -12,14 +12,14 @@ OPTIONS
     address of the source filesystem, defaults to boot address
   --fromDir
     directory on the source filesystem to copy from, defaults to filesystem root
-  --ignore
-    colon-separated list of directories on the destination filesystem where existing files should not be overwritten
   --name
     new label for the destination filesystem, defaults to OpenOS
   --noboot
     do not prompt to set destination as default boot device
   --nolabelset
     do not label the destination filesystem (overrides --name)
+  --update
+    prompt before overwriting existing, but not identical files (may be slow)
 
 EXAMPLES
   install
@@ -28,5 +28,5 @@ EXAMPLES
   install --from abc --fromDir programs/helloworld --noboot --nolabelset
     Install the files at programs/helloworld on filesystem address abc, without changing the boot device or label.
 
-  install --from 562 --ignore /etc
-    Install all files from filesystem address 562, without overwriting any files in /etc at the destination.
+  install --from 562 --update
+    Install all files from filesystem address 562 and prompt the user before changing any files.

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/update
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/update
@@ -5,11 +5,11 @@ SYNOPSIS
   update [OPTION]...
 
 DESCRIPTION
-  Run the install command so that it reinstalls OpenOS from a filesystem labeled "openos". By default this will not change the filesystem label or default boot device, and any existing files in /etc (such as rc.cfg) are not replaced with their defaults.
+  Run the install command so that it reinstalls OpenOS from a filesystem labeled "openos". By default this will not change the filesystem label or default boot device, and the user is asked before any files are overwritten.
 
 OPTIONS
   Options are the same as for install and can be used to override update's defaults.
 
 EXAMPLES
   update
-    Install OpenOS from the boot filesystem, set the destination as the boot device and label it OpenOS.
+    Update OpenOS and prompt the user before overwriting files.

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/update
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/usr/man/update
@@ -1,0 +1,15 @@
+NAME
+  update - update OpenOS files from an OpenOS install disk
+
+SYNOPSIS
+  update [OPTION]...
+
+DESCRIPTION
+  Run the install command so that it reinstalls OpenOS from a filesystem labeled "openos". By default this will not change the filesystem label or default boot device, and any existing files in /etc (such as rc.cfg) are not replaced with their defaults.
+
+OPTIONS
+  Options are the same as for install and can be used to override update's defaults.
+
+EXAMPLES
+  update
+    Install OpenOS from the boot filesystem, set the destination as the boot device and label it OpenOS.


### PR DESCRIPTION
New `--ignore` flag for `install` to specify destination directories where files should not be overwritten, and `update` command to update OpenOS to a newer version from a floppy. Also, man pages for `install` and `update`.
