### PR TITLE
Fix: standard io streams being closable

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/03_io.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/03_io.lua
@@ -60,5 +60,9 @@ io.stderr = buffer.new("w", stderrStream)
 io.stdout:setvbuf("no")
 io.stderr:setvbuf("no")
 
+io.stdin.close = stdinStream.close
+io.stdout.close = stdinStream.close
+io.stderr.close = stdinStream.close
+
 io.input(io.stdin)
 io.output(io.stdout)


### PR DESCRIPTION
To be exact: Not the streams themselves but the buffers on top of them can be closed.
I noticed that because "ls" didn't display anything after some experiments involving an "stdout" file.
