### PR TITLE
Allow [name]/init.lua in require.

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/package.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/package.lua
@@ -1,6 +1,6 @@
 local package = {}
 
-package.path = "/lib/?.lua;/usr/lib/?.lua;/home/lib/?.lua;./?.lua"
+package.path = "/lib/?.lua;/usr/lib/?.lua;/home/lib/?.lua;./?.lua;/lib/?/init.lua;/usr/lib/?/init.lua;/home/lib/?/init.lua;./?/init.lua"
 
 local loading = {}
 


### PR DESCRIPTION
This change allows to store complex libraries in one directory.
