### PR TITLE
Handle a string parameter for keyboard.isKeyDown()

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/keyboard.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/keyboard.lua
@@ -158,7 +158,7 @@ end
 function keyboard.isKeyDown(charOrCode)
   checkArg(1, charOrCode, "string", "number")
   if type(charOrCode) == "string" then
-    return keyboard.pressedChars[charOrCode]
+    return keyboard.pressedChars[charOrCode:byte()] -- we ignore unicode codepoints for now
   elseif type(charOrCode) == "number" then
     return keyboard.pressedCodes[charOrCode]
   end


### PR DESCRIPTION
keyboard.isKeyDown() accepts a string, but doesn't do anything sensible in the case a string is passed.

keyboard.pressedChars[] is always indexed by the unicode codepoint (maps to ASCII in the simple case), so passing a string currently always returns nil.

The proposed tweak changes that. Alternatively, we shouldn't be allowing strings in the first place, I guess.
