### PR TITLE
Enable Travis caching feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ env:
 
 install: gradle setupCIWorkspace
 script: gradle build
+
+cache:
+  directories:
+  - $HOME/.gradle/caches


### PR DESCRIPTION
... because currently builds run for 11 minutes just to download all dependencies.

[Travis docs](http://docs.travis-ci.com/user/caching/)
