### PR TITLE
Change usage of gitref in versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,12 @@ def getGitRef() {
 
 if (System.getenv("BUILD_NUMBER") != null)
     version += ".${System.getenv("BUILD_NUMBER")}"
-else
-    version += "-" + getGitRef()
 
 if (config.oc.subversion != null && config.oc.subversion != "")
     version += "-${config.oc.subversion}"
+
+if (System.getenv("BUILD_NUMBER") == null)
+    version += "+" + getGitRef()
 
 ext.simpleVersion = version
 version = "MC${config.minecraft.version}-${project.version}"


### PR DESCRIPTION
As git ref hash can't be used to order versions it should be only used to denote differences between them.
By using plus sign instead of hyphen many version compression scripts and similar will stop confusing custom build versions.
It is also then compatible with SemVer version 2 ordering rules as for points 10 and 11.
It also was moved at the end so it is more obvious that it a metadata.
http://semver.org

It won't break any of dep configurations as it is only used in unofficial builds.
