### PR TITLE
Add password-protected debug cards

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1358,9 +1358,10 @@ opencomputers {
     # Enable debug card functionality. This may also be of use for custom
     # maps, so it is enabled by default. If you run a server where people
     # may cheat in items but should not have op/admin-like rights, you may
-    # want to set this to false. This will *not* remove the card, it will
-    # just make all functions it provides error out.
-    enableDebugCard: true
+    # want to set this to false. Set this to string if you want to allow
+    # debug card usage to those who knows the password. This will *not*
+    # remove the card, it will just make all functions it provides error out.
+    debugCardAccess: true
 
     # Whether to always register the LuaJ architecture - even if the native
     # library is available. In that case it is possible to switch between

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -11,6 +11,7 @@ import com.typesafe.config._
 import cpw.mods.fml.common.Loader
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion
 import cpw.mods.fml.common.versioning.VersionRange
+import li.cil.oc.Settings.DebugCardAccess
 import li.cil.oc.api.component.TextBuffer.ColorDepth
 import li.cil.oc.common.Tier
 import li.cil.oc.integration.Mods
@@ -380,7 +381,11 @@ class Settings(val config: Config) {
   val nativeInTmpDir = config.getBoolean("debug.nativeInTmpDir")
   val periodicallyForceLightUpdate = config.getBoolean("debug.periodicallyForceLightUpdate")
   val insertIdsInConverters = config.getBoolean("debug.insertIdsInConverters")
-  val enableDebugCard = config.getBoolean("debug.enableDebugCard")
+  val debugCardAccess = config.getAnyRef("debug.debugCardAccess") match {
+    case s: String => DebugCardAccess.Password(s)
+    case java.lang.Boolean.TRUE => DebugCardAccess.Allowed
+    case java.lang.Boolean.FALSE => DebugCardAccess.Forbidden
+  }
   val registerLuaJArchitecture = config.getBoolean("debug.registerLuaJArchitecture")
   val disableLocaleChanging = config.getBoolean("debug.disableLocaleChanging")
 }
@@ -520,4 +525,12 @@ object Settings {
     def apply(inetAddress: InetAddress, host: String) = validator(inetAddress, host)
   }
 
+  object DebugCardAccess {
+    sealed abstract class Base
+
+    object Forbidden extends Base
+    object Allowed extends Base
+
+    case class Password(pwd: String) extends Base
+  }
 }

--- a/src/main/scala/li/cil/oc/server/component/DebugCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/DebugCard.scala
@@ -5,6 +5,7 @@ import cpw.mods.fml.common.Loader
 import cpw.mods.fml.common.ModAPIManager
 import li.cil.oc.OpenComputers
 import li.cil.oc.Settings
+import li.cil.oc.Settings.DebugCardAccess.Allowed
 import li.cil.oc.api.Network
 import li.cil.oc.api.driver.EnvironmentHost
 import li.cil.oc.api.machine.Arguments
@@ -16,7 +17,7 @@ import li.cil.oc.api.network.SidedEnvironment
 import li.cil.oc.api.network.Visibility
 import li.cil.oc.api.prefab
 import li.cil.oc.api.prefab.AbstractValue
-import li.cil.oc.server.component.DebugCard.CommandSender
+import li.cil.oc.server.component.DebugCard.{WorldValue, PasswordCapable, EffectivePassword, CommandSender}
 import li.cil.oc.util.BlockPosition
 import li.cil.oc.util.ExtendedArguments._
 import li.cil.oc.util.ExtendedNBT._
@@ -45,7 +46,7 @@ import net.minecraftforge.fluids.IFluidHandler
 import scala.collection.convert.WrapAsScala._
 import scala.collection.mutable
 
-class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
+class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment with PasswordCapable {
   override val node = Network.newNode(this, Visibility.Neighbors).
     withComponent("debug").
     withConnector().
@@ -60,6 +61,9 @@ class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
   // Player this card is bound to (if any) to use for permissions.
   var player: Option[String] = None
 
+  // Current data card password
+  implicit var effectivePassword: Option[EffectivePassword] = None
+
   private lazy val CommandSender = {
     def defaultFakePlayer = FakePlayerFactory.get(host.world.asInstanceOf[WorldServer], Settings.get.fakePlayerProfile)
     new CommandSender(host, player match {
@@ -73,67 +77,81 @@ class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
 
   // ----------------------------------------------------------------------- //
 
-  import li.cil.oc.server.component.DebugCard.checkEnabled
+  import li.cil.oc.server.component.DebugCard.checkAccess
+
+  @Callback(doc = """function([passwd:string]) -- Tries to unlock this debug card""")
+  def unlock(context: Context, args: Arguments): Array[AnyRef] = {
+    effectivePassword =
+      if (args.count() == 0)
+        None
+      else
+        Some(EffectivePassword(args.checkString(0)))
+
+    checkAccess()
+    result()
+  }
 
   @Callback(doc = """function(value:number):number -- Changes the component network's energy buffer by the specified delta.""")
   def changeBuffer(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     result(node.changeBuffer(args.checkDouble(0)))
   }
 
   @Callback(doc = """function():number -- Get the container's X position in the world.""")
   def getX(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     result(host.xPosition)
   }
 
   @Callback(doc = """function():number -- Get the container's Y position in the world.""")
   def getY(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     result(host.yPosition)
   }
 
   @Callback(doc = """function():number -- Get the container's Z position in the world.""")
   def getZ(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     result(host.zPosition)
   }
 
   @Callback(doc = """function([id:number]):userdata -- Get the world object for the specified dimension ID, or the container's.""")
   def getWorld(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
-    if (args.count() > 0) result(new DebugCard.WorldValue(DimensionManager.getWorld(args.checkInteger(0))))
-    else result(new DebugCard.WorldValue(host.world))
+    checkAccess()
+    result(new WorldValue(
+      if (args.count() > 0) DimensionManager.getWorld(args.checkInteger(0)) else host.world(),
+      effectivePassword
+    ))
   }
 
   @Callback(doc = """function():table -- Get a list of all world IDs, loaded and unloaded.""")
   def getWorlds(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     result(DimensionManager.getStaticDimensionIDs)
   }
 
   @Callback(doc = """function(name:string):userdata -- Get the entity of a player.""")
   def getPlayer(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
-    result(new DebugCard.PlayerValue(args.checkString(0)))
+    checkAccess()
+    result(new DebugCard.PlayerValue(args.checkString(0), effectivePassword))
   }
 
   @Callback(doc = """function():table -- Get a list of currently logged-in players.""")
   def getPlayers(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     result(MinecraftServer.getServer.getAllUsernames)
   }
 
   @Callback(doc = """function(name:string):boolean -- Get whether a mod or API is loaded.""")
   def isModLoaded(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     val name = args.checkString(0)
     result(Loader.isModLoaded(name) || ModAPIManager.INSTANCE.hasAPI(name))
   }
 
   @Callback(doc = """function(command:string):number -- Runs an arbitrary command using a fake player.""")
   def runCommand(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     val commands =
       if (args.isTable(0)) collectionAsScalaIterable(args.checkTable(0).values())
       else Iterable(args.checkString(0))
@@ -150,7 +168,7 @@ class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
 
   @Callback(doc = """function(x:number, y:number, z:number):boolean -- Connect the debug card to the block at the specified coordinates.""")
   def connectToBlock(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
     val x = args.checkInteger(0)
     val y = args.checkInteger(1)
     val z = args.checkInteger(2)
@@ -178,7 +196,7 @@ class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
 
   @Callback(doc = """function():userdata -- Test method for user-data and general value conversion.""")
   def test(context: Context, args: Arguments): Array[AnyRef] = {
-    checkEnabled()
+    checkAccess()
 
     val v1 = mutable.Map("a" -> true, "b" -> "test")
     val v2 = Map(10 -> "zxc", false -> v1)
@@ -225,6 +243,9 @@ class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
     if (nbt.hasKey(Settings.namespace + "player")) {
       player = Option(nbt.getString(Settings.namespace + "player"))
     }
+    if (nbt.hasKey(Settings.namespace + "password")) {
+      effectivePassword = Some(EffectivePassword(nbt.getString(Settings.namespace + "password")))
+    }
   }
 
   override def save(nbt: NBTTagCompound): Unit = {
@@ -236,6 +257,7 @@ class DebugCard(host: EnvironmentHost) extends prefab.ManagedEnvironment {
         nbt.setInteger(Settings.namespace + "remoteZ", z)
     }
     player.foreach(nbt.setString(Settings.namespace + "player", _))
+    effectivePassword.map(_.password).filter(_.nonEmpty).foreach(nbt.setString(Settings.namespace + "password", _))
   }
 }
 
@@ -243,15 +265,46 @@ object DebugCard {
 
   import li.cil.oc.util.ResultWrapper.result
 
-  def checkEnabled() = if (!Settings.get.enableDebugCard) throw new Exception("debug card functionality is disabled")
+  def checkAccess()(implicit passwd: Option[EffectivePassword]) = Settings.get.debugCardAccess match {
+    case Settings.DebugCardAccess.Allowed =>
+    case Settings.DebugCardAccess.Forbidden => throw new IllegalArgumentException("data card functionality is disabled")
+    case Settings.DebugCardAccess.Password(pwd) => passwd match {
+      case Some(EffectivePassword(pwd1)) => if (pwd != pwd1) throw new IllegalArgumentException("incorrect password")
+      case None => throw new IllegalArgumentException("data card functionality is protected with password")
+    }
+  }
 
-  class PlayerValue(var name: String) extends prefab.AbstractValue {
-    def this() = this("") // For loading.
+  case class EffectivePassword(password: String)
+
+  trait PasswordCapable {
+    implicit def effectivePassword: Option[EffectivePassword]
+  }
+
+  abstract class DataCardValue(private var _effectivePassword: Option[EffectivePassword])
+           extends prefab.AbstractValue with PasswordCapable {
+
+    override implicit def effectivePassword: Option[EffectivePassword] = _effectivePassword
+
+    override def save(nbt: NBTTagCompound): Unit = {
+      super.save(nbt)
+      _effectivePassword.map(_.password).filter(_.nonEmpty).foreach(nbt.setString("password", _))
+    }
+
+    override def load(nbt: NBTTagCompound): Unit = {
+      super.load(nbt)
+      if (nbt.hasKey("password")) {
+        _effectivePassword = Some(EffectivePassword(nbt.getString("password")))
+      }
+    }
+  }
+
+  class PlayerValue(var name: String, _pwd: Option[EffectivePassword]) extends DataCardValue(_pwd) {
+    def this() = this("", None) // For loading.
 
     // ----------------------------------------------------------------------- //
 
     def withPlayer(f: (EntityPlayerMP) => Array[AnyRef]) = {
-      checkEnabled()
+      checkAccess()
       MinecraftServer.getServer.getConfigurationManager.func_152612_a(name) match {
         case player: EntityPlayerMP => f(player)
         case _ => result(Unit, "player is offline")
@@ -260,7 +313,7 @@ object DebugCard {
 
     @Callback(doc = """function():userdata -- Get the player's world object.""")
     def getWorld(context: Context, args: Arguments): Array[AnyRef] = {
-      withPlayer(player => result(new DebugCard.WorldValue(player.getEntityWorld)))
+      withPlayer(player => result(new DebugCard.WorldValue(player.getEntityWorld, effectivePassword)))
     }
 
     @Callback(doc = """function():string -- Get the player's game type.""")
@@ -313,77 +366,77 @@ object DebugCard {
     }
   }
 
-  class WorldValue(var world: World) extends prefab.AbstractValue {
-    def this() = this(null) // For loading.
+  class WorldValue(var world: World, _pwd: Option[EffectivePassword]) extends DataCardValue(_pwd) {
+    def this() = this(null, None) // For loading.
 
     // ----------------------------------------------------------------------- //
 
     @Callback(doc = """function():number -- Gets the numeric id of the current dimension.""")
     def getDimensionId(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.provider.dimensionId)
     }
 
     @Callback(doc = """function():string -- Gets the name of the current dimension.""")
     def getDimensionName(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.provider.getDimensionName)
     }
 
     @Callback(doc = """function():number -- Gets the seed of the world.""")
     def getSeed(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.getSeed)
     }
 
     @Callback(doc = """function():boolean -- Returns whether it is currently raining.""")
     def isRaining(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.isRaining)
     }
 
     @Callback(doc = """function(value:boolean) -- Sets whether it is currently raining.""")
     def setRaining(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       world.getWorldInfo.setRaining(args.checkBoolean(0))
       null
     }
 
     @Callback(doc = """function():boolean -- Returns whether it is currently thundering.""")
     def isThundering(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.isThundering)
     }
 
     @Callback(doc = """function(value:boolean) -- Sets whether it is currently thundering.""")
     def setThundering(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       world.getWorldInfo.setThundering(args.checkBoolean(0))
       null
     }
 
     @Callback(doc = """function():number -- Get the current world time.""")
     def getTime(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.getWorldTime)
     }
 
     @Callback(doc = """function(value:number) -- Set the current world time.""")
     def setTime(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       world.setWorldTime(args.checkDouble(0).toLong)
       null
     }
 
     @Callback(doc = """function():number, number, number -- Get the current spawn point coordinates.""")
     def getSpawnPoint(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.getWorldInfo.getSpawnX, world.getWorldInfo.getSpawnY, world.getWorldInfo.getSpawnZ)
     }
 
     @Callback(doc = """function(x:number, y:number, z:number) -- Set the spawn point coordinates.""")
     def setSpawnPoint(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       world.getWorldInfo.setSpawnPosition(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))
       null
     }
@@ -392,25 +445,25 @@ object DebugCard {
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Get the ID of the block at the specified coordinates.""")
     def getBlockId(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(Block.getIdFromBlock(world.getBlock(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))))
     }
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Get the metadata of the block at the specified coordinates.""")
     def getMetadata(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.getBlockMetadata(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2)))
     }
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Check whether the block at the specified coordinates is loaded.""")
     def isLoaded(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.blockExists(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2)))
     }
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Check whether the block at the specified coordinates has a tile entity.""")
     def hasTileEntity(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val (x, y, z) = (args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))
       val block = world.getBlock(x, y, z)
       result(block != null && block.hasTileEntity(world.getBlockMetadata(x, y, z)))
@@ -418,7 +471,7 @@ object DebugCard {
 
     @Callback(doc = """function(x:number, y:number, z:number):table -- Get the NBT of the block at the specified coordinates.""")
     def getTileNBT(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val (x, y, z) = (args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))
       world.getTileEntity(x, y, z) match {
         case tileEntity: TileEntity => result(toNbt(tileEntity).toTypedMap)
@@ -428,7 +481,7 @@ object DebugCard {
 
     @Callback(doc = """function(x:number, y:number, z:number, nbt:table):boolean -- Set the NBT of the block at the specified coordinates.""")
     def setTileNBT(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val (x, y, z) = (args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))
       world.getTileEntity(x, y, z) match {
         case tileEntity: TileEntity =>
@@ -446,25 +499,25 @@ object DebugCard {
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Get the light opacity of the block at the specified coordinates.""")
     def getLightOpacity(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.getBlockLightOpacity(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2)))
     }
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Get the light value (emission) of the block at the specified coordinates.""")
     def getLightValue(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.getBlockLightValue(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2)))
     }
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Get whether the block at the specified coordinates is directly under the sky.""")
     def canSeeSky(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       result(world.canBlockSeeTheSky(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2)))
     }
 
     @Callback(doc = """function(x:number, y:number, z:number, id:number or string, meta:number):number -- Set the block at the specified coordinates.""")
     def setBlock(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val block = if (args.isInteger(3)) Block.getBlockById(args.checkInteger(3)) else Block.getBlockFromName(args.checkString(3))
       val metadata = args.checkInteger(4)
       result(world.setBlock(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2), block, metadata, 3))
@@ -472,7 +525,7 @@ object DebugCard {
 
     @Callback(doc = """function(x1:number, y1:number, z1:number, x2:number, y2:number, z2:number, id:number or string, meta:number):number -- Set all blocks in the area defined by the two corner points (x1, y1, z1) and (x2, y2, z2).""")
     def setBlocks(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val (xMin, yMin, zMin) = (args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))
       val (xMax, yMax, zMax) = (args.checkInteger(3), args.checkInteger(4), args.checkInteger(5))
       val block = if (args.isInteger(6)) Block.getBlockById(args.checkInteger(6)) else Block.getBlockFromName(args.checkString(6))
@@ -491,7 +544,7 @@ object DebugCard {
 
     @Callback(doc = """function(id:string, count:number, damage:number, nbt:string, x:number, y:number, z:number, side:number):boolean - Insert an item stack into the inventory at the specified location. NBT tag is expected in JSON format.""")
     def insertItem(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val item = Item.itemRegistry.getObject(args.checkString(0)).asInstanceOf[Item]
       if (item == null) {
         throw new IllegalArgumentException("invalid item id")
@@ -513,7 +566,7 @@ object DebugCard {
 
     @Callback(doc = """function(x:number, y:number, z:number, slot:number[, count:number]):number - Reduce the size of an item stack in the inventory at the specified location.""")
     def removeItem(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val position = BlockPosition(args.checkDouble(0), args.checkDouble(1), args.checkDouble(2), world)
       InventoryUtils.inventoryAt(position) match {
         case Some(inventory) =>
@@ -528,7 +581,7 @@ object DebugCard {
 
     @Callback(doc = """function(id:string, amount:number, x:number, y:number, z:number, side:number):boolean - Insert some fluid into the tank at the specified location.""")
     def insertFluid(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val fluid = FluidRegistry.getFluid(args.checkString(0))
       if (fluid == null) {
         throw new IllegalArgumentException("invalid fluid id")
@@ -544,7 +597,7 @@ object DebugCard {
 
     @Callback(doc = """function(amount:number, x:number, y:number, z:number, side:number):boolean - Remove some fluid from a tank at the specified location.""")
     def removeFluid(context: Context, args: Arguments): Array[AnyRef] = {
-      checkEnabled()
+      checkAccess()
       val amount = args.checkInteger(0)
       val position = BlockPosition(args.checkDouble(1), args.checkDouble(2), args.checkDouble(3), world)
       val side = args.checkSide(4, ForgeDirection.VALID_DIRECTIONS: _*)


### PR DESCRIPTION
- Config property `enableDebugCard` was renamed to `debugCardAccess` (does not renames value in existing configs yet)
- `true` and `false` are treated like before - completely enables/disables debug card. String values are treated as a password that must be passed to `debug.unlock(string)` to enable all other debug card functions.

Change is intended for servers where people may cheat in items but admins need debug card.
