### PR TITLE
use path as given by user in sh shell in tab completion

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
@@ -450,7 +450,12 @@ local function hintHandler(line, cursor)
     partialPrefix = partialPrefix:sub(1, -name:len() - 1)
     result = getMatchingFiles(partialPrefix, name)
   end
-  local resultSuffix = ((searchInPath or #result == 1) and " " or "")
+  local resultSuffix = ""
+  if searchInPath then
+    resultSuffix  = " "
+  elseif #result == 1 and result[1]:sub(-1) ~= '/' then
+    resultSuffix = " "
+  end
   prefix = prefix or ""
   for i = 1, #result do
     result[i] = prefix .. result[i] .. resultSuffix


### PR DESCRIPTION
This changes tab completion for non-PATH search items in the sh shell. searchInPath is unaffected.
e.g.
if pwd has a file called re.lua and read.lua
./re{tab}
resolves to
./re.lua
and then {tab} again resolves to
./read.lua

previously (i.e. without this change) the {tab} would complete to:
/path/to/pwd/re.lua
and
/path/to/pwd/read.lua
respectively

The goal here is to preserve the path string (which may contain . or ..) the user has entered and not replace it with the results of shell.resolve (visually)

Also, single match completions will append a space after the file name, indicating to the user that they have correctly spelled the name of a file, uniquely

e.g. same pwd as above
./read{tab}
resolves to
./read.lua{space}

But not for directories, to allow the user to continue typing a path (as before)
