### PR TITLE
Sh patch

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
@@ -384,6 +384,10 @@ end
 local args, options = shell.parse(...)
 local history = {}
 
+local function escapeMagic(text)
+  return text:gsub('[%(%)%.%%%+%-%*%?%[%^%$]', '%%%1')
+end
+
 local function getMatchingPrograms(baseName)
   local result = {}
   -- TODO only matching files with .lua extension for now, might want to
@@ -391,7 +395,7 @@ local function getMatchingPrograms(baseName)
   if not baseName or #baseName == 0 then
     baseName = "^(.*)%.lua$"
   else
-    baseName = "^(" .. baseName .. ".*)%.lua$"
+    baseName = "^(" .. escapeMagic(baseName) .. ".*)%.lua$"
   end
   for basePath in string.gmatch(os.getenv("PATH"), "[^:]+") do
     for file in fs.list(basePath) do
@@ -404,7 +408,8 @@ local function getMatchingPrograms(baseName)
   return result
 end
 
-local function getMatchingFiles(baseName)
+local function getMatchingFiles(partialPrefix, name)
+  local baseName = shell.resolve(partialPrefix .. name)
   local result, basePath = {}
   -- note: we strip the trailing / to make it easier to navigate through
   -- directories using tab completion (since entering the / will then serve
@@ -416,12 +421,12 @@ local function getMatchingFiles(baseName)
     baseName = "^(.-)/?$"
   else
     basePath = fs.path(baseName) or "/"
-    baseName = "^(" .. fs.name(baseName) .. ".-)/?$"
+    baseName = "^(" .. escapeMagic(fs.name(baseName)) .. ".-)/?$"
   end
   for file in fs.list(basePath) do
     local match = file:match(baseName)
     if match then
-      table.insert(result, fs.concat(basePath, match))
+      table.insert(result, partialPrefix ..  match)
     end
   end
   -- (cont.) but if there's only one match and it's a directory, *then* we
@@ -444,10 +449,20 @@ local function hintHandler(line, cursor)
     -- first part and no path, look for programs in the $PATH
     result = getMatchingPrograms(line)
   else -- just look normal files
-    result = getMatchingFiles(shell.resolve(partial or line))
+    local partialPrefix = (partial or line)
+    local name = fs.name(partialPrefix)
+    partialPrefix = partialPrefix:sub(1, -name:len() - 1)
+    result = getMatchingFiles(partialPrefix, name)
   end
+  local resultSuffix = ""
+  if searchInPath then
+    resultSuffix  = " "
+  elseif #result == 1 and result[1]:sub(-1) ~= '/' then
+    resultSuffix = " "
+  end
+  prefix = prefix or ""
   for i = 1, #result do
-    result[i] = (prefix or "") .. result[i] .. (searchInPath and " " or "")
+    result[i] = prefix .. result[i] .. resultSuffix
   end
   table.sort(result)
   return result


### PR DESCRIPTION
This changes tab completion for search items in the sh shell. 

For file name completion, the path as entered by the user is unaltered visually
e.g.
if pwd has a file called re.lua and read.lua
./re{tab}
resolves to
./re.lua
and then {tab} again resolves to
./read.lua

previously (i.e. without this change) the {tab} would complete to:
/path/to/pwd/re.lua
and
/path/to/pwd/read.lua
respectively

The goal here is to preserve the path string (which may contain . or ..) the user has entered and not replace it with the results of shell.resolve (visually)

Also, single match completions will append a space after the file name, indicating to the user that they have correctly spelled the name of a file, uniquely

e.g. same pwd as above
./read{tab}
resolves to
./read.lua{space}

But not for directories, to allow the user to continue typing a path (as before)

Additionally for both program search and path search, if the path contains magic characters previously the tab completion pattern matching would fail. Thus, this patch contains a method to escape all magic characters before pattern matching is run on user input.
