### PR TITLE
Added term windows and multiscreen support to keyboard lib

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/dmesg.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/dmesg.lua
@@ -1,13 +1,16 @@
 local event = require "event"
-local component = require "component"
+local term = require "term"
 local keyboard = require "keyboard"
 
 local args = {...}
 
 local interactive = io.output() == io.stdout
+local function gpu()
+  return select(2, term.getGPU())
+end
 local color, isPal, evt
 if interactive then
-  color, isPal = component.gpu.getForeground()
+  color, isPal = gpu().getForeground()
 end
 io.write("Press 'Ctrl-C' to exit\n")
 pcall(function()
@@ -17,13 +20,13 @@ pcall(function()
     else
       evt = table.pack(event.pull())
     end
-    if interactive then component.gpu.setForeground(0xCC2200) end
+    if interactive then gpu().setForeground(0xCC2200) end
     io.write("[" .. os.date("%T") .. "] ")
-    if interactive then component.gpu.setForeground(0x44CC00) end
+    if interactive then gpu().setForeground(0x44CC00) end
     io.write(tostring(evt[1]) .. string.rep(" ", math.max(10 - #tostring(evt[1]), 0) + 1))
-    if interactive then component.gpu.setForeground(0xB0B00F) end
+    if interactive then gpu().setForeground(0xB0B00F) end
     io.write(tostring(evt[2]) .. string.rep(" ", 37 - #tostring(evt[2])))
-    if interactive then component.gpu.setForeground(0xFFFFFF) end
+    if interactive then gpu().setForeground(0xFFFFFF) end
     if evt.n > 2 then
       for i = 3, evt.n do
         io.write("  " .. tostring(evt[i]))
@@ -34,6 +37,6 @@ pcall(function()
   until evt[1] == "interrupted"
 end)
 if interactive then
-  component.gpu.setForeground(color, isPal)
+  gpu().setForeground(color, isPal)
 end
 

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/edit.lua
@@ -1,4 +1,3 @@
-local component = require("component")
 local event = require("event")
 local fs = require("filesystem")
 local keyboard = require("keyboard")
@@ -10,6 +9,11 @@ local unicode = require("unicode")
 if not term.isAvailable() then
   return
 end
+
+local function gpu()
+  return select(2, term.getGPU())
+end
+
 
 local args, options = shell.parse(...)
 if #args == 0 then
@@ -114,13 +118,60 @@ end
 -------------------------------------------------------------------------------
 
 local function setStatus(value)
-  local w, h = component.gpu.getResolution()
-  component.gpu.set(1, h, text.padRight(unicode.sub(value, 1, w - 10), w - 10))
+  local x, y, w, h = term.getGlobalArea()
+  value = unicode.wlen(value) > w - 10 and unicode.wtrunc(value, w - 9) or value
+  value = text.padRight(value, w - 10)
+  gpu().set(x, y + h - 1, value)
 end
 
-local function getSize()
-  local w, h = component.gpu.getResolution()
-  return w, h - 1
+local function getArea()
+  local x, y, w, h = term.getGlobalArea()
+  return x, y, w, h - 1
+end
+
+local function removePrefix(line, length)
+  if length >= unicode.wlen(line) then
+    return ""
+  else
+    local prefix = unicode.wtrunc(line, length + 1)
+    local suffix = unicode.sub(line, unicode.len(prefix) + 1)
+    length = length - unicode.wlen(prefix)
+    if length > 0 then
+      suffix = (" "):rep(unicode.charWidth(suffix) - length) .. unicode.sub(suffix, 2)
+    end
+    return suffix
+  end
+end
+
+local function lengthToChars(line, length)
+  if length > unicode.wlen(line) then
+    return unicode.len(line) + 1
+  else
+    local prefix = unicode.wtrunc(line, length)
+    return unicode.len(prefix) + 1
+  end
+end
+
+
+local function isWideAtPosition(line, x)
+  local index = lengthToChars(line, x)
+  if index > unicode.len(line) then
+    return false, false
+  end
+  local prefix = unicode.sub(line, 1, index)
+  local char = unicode.sub(line, index, index)
+  --isWide, isRight
+  return unicode.isWide(char), unicode.wlen(prefix) == x
+end
+
+local function drawLine(x, y, w, h, lineNr)
+  local yLocal = lineNr - scrollY
+  if yLocal > 0 and yLocal <= h then
+    local str = removePrefix(buffer[lineNr] or "", scrollX)
+    str = unicode.wlen(str) > w and unicode.wtrunc(str, w + 1) or str
+    str = text.padRight(str, w)
+    gpu().set(x, y - 1 + lineNr - scrollY, str)
+  end
 end
 
 local function getCursor()
@@ -133,8 +184,17 @@ local function line()
   return buffer[cby]
 end
 
+local function getNormalizedCursor()
+  local cbx, cby = getCursor()
+  local wide, right = isWideAtPosition(buffer[cby], cbx)
+  if wide and right then
+    cbx = cbx - 1
+  end
+  return cbx, cby
+end
+
 local function setCursor(nbx, nby)
-  local w, h = getSize()
+  local x, y, w, h = getArea()
   nby = math.max(1, math.min(#buffer, nby))
 
   local ncy = nby - scrollY
@@ -143,75 +203,70 @@ local function setCursor(nbx, nby)
     local sy = nby - h
     local dy = math.abs(scrollY - sy)
     scrollY = sy
-    component.gpu.copy(1, 1 + dy, w, h - dy, 0, -dy)
-    for by = nby - (dy - 1), nby do
-      local str = text.padRight(unicode.sub(buffer[by], 1 + scrollX), w)
-      component.gpu.set(1, by - scrollY, str)
+    if h > dy then
+      gpu().copy(x, y + dy, w, h - dy, 0, -dy)
+    end
+    for lineNr = nby - (math.min(dy, h) - 1), nby do
+      drawLine(x, y, w, h, lineNr)
     end
   elseif ncy < 1 then
     term.setCursorBlink(false)
     local sy = nby - 1
     local dy = math.abs(scrollY - sy)
     scrollY = sy
-    component.gpu.copy(1, 1, w, h - dy, 0, dy)
-    for by = nby, nby + (dy - 1) do
-      local str = text.padRight(unicode.sub(buffer[by], 1 + scrollX), w)
-      component.gpu.set(1, by - scrollY, str)
+    if h > dy then
+      gpu().copy(x, y, w, h - dy, 0, dy)
+    end
+    for lineNr = nby, nby + (math.min(dy, h) - 1) do
+      drawLine(x, y, w, h, lineNr)
     end
   end
   term.setCursor(term.getCursor(), nby - scrollY)
 
-  nbx = math.max(1, math.min(unicode.len(line()) + 1, nbx))
+  nbx = math.max(1, math.min(unicode.wlen(line()) + 1, nbx))
+  local wide, right = isWideAtPosition(line(), nbx)
   local ncx = nbx - scrollX
-  if ncx > w then
+  if ncx > w or (ncx + 1 > w and wide and not right) then
     term.setCursorBlink(false)
-    local sx = nbx - w
-    local dx = math.abs(scrollX - sx)
-    scrollX = sx
-    component.gpu.copy(1 + dx, 1, w - dx, h, -dx, 0)
-    for by = 1 + scrollY, math.min(h + scrollY, #buffer) do
-      local str = unicode.sub(buffer[by], nbx - (dx - 1), nbx)
-      str = text.padRight(str, dx)
-      component.gpu.set(1 + (w - dx), by - scrollY, str)
+    scrollX = nbx - w + ((wide and not right) and 1 or 0)
+    for lineNr = 1 + scrollY, math.min(h + scrollY, #buffer) do
+      drawLine(x, y, w, h, lineNr)
     end
-  elseif ncx < 1 then
+  elseif ncx < 1 or (ncx - 1 < 1 and wide and right) then
     term.setCursorBlink(false)
-    local sx = nbx - 1
-    local dx = math.abs(scrollX - sx)
-    scrollX = sx
-    component.gpu.copy(1, 1, w - dx, h, dx, 0)
-    for by = 1 + scrollY, math.min(h + scrollY, #buffer) do
-      local str = unicode.sub(buffer[by], nbx, nbx + dx)
-      --str = text.padRight(str, dx)
-      component.gpu.set(1, by - scrollY, str)
+    scrollX = nbx - 1 - ((wide and right) and 1 or 0)
+    for lineNr = 1 + scrollY, math.min(h + scrollY, #buffer) do
+      drawLine(x, y, w, h, lineNr)
     end
   end
   term.setCursor(nbx - scrollX, nby - scrollY)
-
-  component.gpu.set(w - 9, h + 1, text.padLeft(string.format("%d,%d", nby, nbx), 10))
+  --update with term lib
+  nbx, nby = getCursor()
+  gpu().set(x + w - 10, y + h, text.padLeft(string.format("%d,%d", nby, nbx), 10))
 end
 
 local function highlight(bx, by, length, enabled)
-  local w, h = getSize()
+  local x, y, w, h = getArea()
   local cx, cy = bx - scrollX, by - scrollY
   cx = math.max(1, math.min(w, cx))
   cy = math.max(1, math.min(h, cy))
   length = math.max(1, math.min(w - cx, length))
 
-  local fg, fgp = component.gpu.getForeground()
-  local bg, bgp = component.gpu.getBackground()
+  local fg, fgp = gpu().getForeground()
+  local bg, bgp = gpu().getBackground()
   if enabled then
-    component.gpu.setForeground(bg, bgp)
-    component.gpu.setBackground(fg, fgp)
+    gpu().setForeground(bg, bgp)
+    gpu().setBackground(fg, fgp)
   end
-  local value = ""
-  for x = cx, cx + length - 1 do
-    value = value .. component.gpu.get(x, cy)
+  local indexFrom = lengthToChars(buffer[by], bx)
+  local value = unicode.sub(buffer[by], indexFrom)
+  if unicode.wlen(value) > length then
+    value = unicode.wtrunc(value, length + 1)
   end
-  component.gpu.set(cx, cy, value)
+  gpu().set(x - 1 + cx, y - 1 + cy, value)
   if enabled then
-    component.gpu.setForeground(fg, fgp)
-    component.gpu.setBackground(bg, bgp)
+    gpu().setForeground(fg, fgp)
+    gpu().setBackground(bg, bgp)
   end
 end
 
@@ -222,13 +277,18 @@ end
 
 local function ende()
   local cbx, cby = getCursor()
-  setCursor(unicode.len(line()) + 1, cby)
+  setCursor(unicode.wlen(line()) + 1, cby)
 end
 
 local function left()
-  local cbx, cby = getCursor()
+  local cbx, cby = getNormalizedCursor()
   if cbx > 1 then
-    setCursor(cbx - 1, cby)
+    local wideTarget, rightTarget = isWideAtPosition(line(), cbx - 1)
+    if wideTarget and rightTarget then
+      setCursor(cbx - 2, cby)
+    else
+      setCursor(cbx - 1, cby)
+    end
     return true -- for backspace
   elseif cby > 1 then
     setCursor(cbx, cby - 1)
@@ -239,9 +299,13 @@ end
 
 local function right(n)
   n = n or 1
-  local cbx, cby = getCursor()
-  local be = unicode.len(line()) + 1
-  if cbx < be then
+  local cbx, cby = getNormalizedCursor()
+  local be = unicode.wlen(line()) + 1
+  local wide, right = isWideAtPosition(line(), cbx + n)
+  if wide and right then
+    n = n + 1
+  end
+  if cbx + n <= be then
     setCursor(cbx + n, cby)
   elseif cby < #buffer then
     setCursor(1, cby + 1)
@@ -253,9 +317,6 @@ local function up(n)
   local cbx, cby = getCursor()
   if cby > 1 then
     setCursor(cbx, cby - n)
-    if getCursor() > unicode.len(line()) then
-      ende()
-    end
   end
 end
 
@@ -264,22 +325,19 @@ local function down(n)
   local cbx, cby = getCursor()
   if cby < #buffer then
     setCursor(cbx, cby + n)
-    if getCursor() > unicode.len(line()) then
-      ende()
-    end
   end
 end
 
 local function delete(fullRow)
   local cx, cy = term.getCursor()
   local cbx, cby = getCursor()
-  local w, h = getSize()
+  local x, y, w, h = getArea()
   local function deleteRow(row)
     local content = table.remove(buffer, row)
     local rcy = cy + (row - cby)
     if rcy <= h then
-      component.gpu.copy(1, rcy + 1, w, h - rcy, 0, -1)
-      component.gpu.set(1, h, text.padRight(buffer[row + (h - rcy)], w))
+      gpu().copy(x, y + rcy, w, h - rcy, 0, -1)
+      drawLine(x, y, w, h, row + (h - rcy))
     end
     return content
   end
@@ -289,25 +347,20 @@ local function delete(fullRow)
       deleteRow(cby)
     else
       buffer[cby] = ""
-      component.gpu.fill(1, cy, w, 1, " ")
+      gpu().fill(x, y - 1 + cy, w, 1, " ")
     end
     setCursor(1, cby)
-  elseif cbx <= unicode.len(line()) then
+  elseif cbx <= unicode.wlen(line()) then
     term.setCursorBlink(false)
-    buffer[cby] = unicode.sub(line(), 1, cbx - 1) ..
-                  unicode.sub(line(), cbx + 1)
-    component.gpu.copy(cx + 1, cy, w - cx, 1, -1, 0)
-    local br = cbx + (w - cx)
-    local char = unicode.sub(line(), br, br)
-    if not char or unicode.len(char) == 0 then
-      char = " "
-    end
-    component.gpu.set(w, cy, char)
+    local index = lengthToChars(line(), cbx)
+    buffer[cby] = unicode.sub(line(), 1, index - 1) ..
+                  unicode.sub(line(), index + 1)
+    drawLine(x, y, w, h, cby)
   elseif cby < #buffer then
     term.setCursorBlink(false)
     local append = deleteRow(cby + 1)
     buffer[cby] = buffer[cby] .. append
-    component.gpu.set(cx, cy, append)
+    drawLine(x, y, w, h, cby)
   else
     return
   end
@@ -321,17 +374,13 @@ local function insert(value)
   term.setCursorBlink(false)
   local cx, cy = term.getCursor()
   local cbx, cby = getCursor()
-  local w, h = getSize()
-  buffer[cby] = unicode.sub(line(), 1, cbx - 1) ..
+  local x, y, w, h = getArea()
+  local index = lengthToChars(line(), cbx)
+  buffer[cby] = unicode.sub(line(), 1, index - 1) ..
                 value ..
-                unicode.sub(line(), cbx)
-  local len = unicode.len(value)
-  local n = w - (cx - 1) - len
-  if n > 0 then
-    component.gpu.copy(cx, cy, n, 1, len, 0)
-  end
-  component.gpu.set(cx, cy, value)
-  right(len)
+                unicode.sub(line(), index)
+  drawLine(x, y, w, h, cby)
+  right(unicode.wlen(value))
   setStatus(helpStatusText())
 end
 
@@ -339,15 +388,16 @@ local function enter()
   term.setCursorBlink(false)
   local cx, cy = term.getCursor()
   local cbx, cby = getCursor()
-  local w, h = getSize()
-  table.insert(buffer, cby + 1, unicode.sub(buffer[cby], cbx))
-  buffer[cby] = unicode.sub(buffer[cby], 1, cbx - 1)
-  component.gpu.fill(cx, cy, w - (cx - 1), 1, " ")
+  local x, y, w, h = getArea()
+  local index = lengthToChars(line(), cbx)
+  table.insert(buffer, cby + 1, unicode.sub(buffer[cby], index))
+  buffer[cby] = unicode.sub(buffer[cby], 1, index - 1)
+  drawLine(x, y, w, h, cby)
   if cy < h then
     if cy < h - 1 then
-      component.gpu.copy(1, cy + 1, w, h - (cy + 1), 0, 1)
+      gpu().copy(x, y + cy, w, h - (cy + 1), 0, 1)
     end
-    component.gpu.set(1, cy + 1, text.padRight(buffer[cby + 1], w))
+    drawLine(x, y, w, h, cby + 1)
   end
   setCursor(1, cby + 1)
   setStatus(helpStatusText())
@@ -356,7 +406,7 @@ end
 local findText = ""
 
 local function find()
-  local w, h = getSize()
+  local x, y, w, h = getArea()
   local cx, cy = term.getCursor()
   local cbx, cby = getCursor()
   local ibx, iby = cbx, cby
@@ -375,28 +425,32 @@ local function find()
         sx = string.find(buffer[sy], findText, nil, true)
       end
       if sx then
+        sx = unicode.wlen(string.sub(buffer[sy], 1, sx - 1)) + 1
         cbx, cby = sx, sy
         setCursor(cbx, cby)
-        highlight(cbx, cby, unicode.len(findText), true)
+        highlight(cbx, cby, unicode.wlen(findText), true)
       end
     end
-    term.setCursor(7 + unicode.len(findText), h + 1)
+    term.setCursor(7 + unicode.wlen(findText), h + 1)
     setStatus("Find: " .. findText)
 
-    local _, _, char, code = event.pull("key_down")
-    local handler, name = getKeyBindHandler(code)
-    highlight(cbx, cby, unicode.len(findText), false)
-    if name == "newline" then
-      break
-    elseif name == "close" then
-      handler()
-    elseif name == "backspace" then
-      findText = unicode.sub(findText, 1, -2)
-    elseif name == "find" or name == "findnext" then
-      ibx = cbx + 1
-      iby = cby
-    elseif not keyboard.isControl(char) then
-      findText = findText .. unicode.char(char)
+    local _, address, char, code = event.pull("key_down")
+    local inFocus, screenAddress, keyboardAddress = term.hasFocus()
+    if inFocus and address == keyboardAddress then
+      local handler, name = getKeyBindHandler(code, keyboardAddress)
+      highlight(cbx, cby, unicode.wlen(findText), false)
+      if name == "newline" then
+        break
+      elseif name == "close" then
+        handler()
+      elseif name == "backspace" then
+        findText = unicode.sub(findText, 1, -2)
+      elseif name == "find" or name == "findnext" then
+        ibx = cbx + 1
+        iby = cby
+      elseif not keyboard.isControl(char) then
+        findText = findText .. unicode.char(char)
+      end
     end
   end
   setCursor(cbx, cby)
@@ -413,11 +467,11 @@ local keyBindHandlers = {
   home = home,
   eol = ende,
   pageUp = function()
-    local w, h = getSize()
+    local x, y, w, h = getArea()
     up(h - 1)
   end,
   pageDown = function()
-    local w, h = getSize()
+    local x, y, w, h = getArea()
     down(h - 1)
   end,
 
@@ -493,7 +547,7 @@ local keyBindHandlers = {
   findnext = find
 }
 
-getKeyBindHandler = function(code)
+getKeyBindHandler = function(code, keyboardAddress)
   if type(config.keybinds) ~= "table" then return end
   -- Look for matches, prefer more 'precise' keybinds, e.g. prefer
   -- ctrl+del over del.
@@ -509,9 +563,9 @@ getKeyBindHandler = function(code)
             elseif value == "shift" then shift = true
             else key = value end
           end
-          if (not alt or keyboard.isAltDown()) and
-             (not control or keyboard.isControlDown()) and
-             (not shift or keyboard.isShiftDown()) and
+          if (not alt or keyboard.isAltDown(keyboardAddress)) and
+             (not control or keyboard.isControlDown(keyboardAddress)) and
+             (not shift or keyboard.isShiftDown(keyboardAddress)) and
              code == keyboard.keys[key] and
              #keybind > resultWeight
           then
@@ -528,8 +582,8 @@ end
 
 -------------------------------------------------------------------------------
 
-local function onKeyDown(char, code)
-  local handler = getKeyBindHandler(code)
+local function onKeyDown(char, code, keyboardAddress)
+  local handler = getKeyBindHandler(code, keyboardAddress)
   if handler then
     handler()
   elseif readonly and code == keyboard.keys.q then
@@ -575,7 +629,7 @@ end
 do
   local f = io.open(filename)
   if f then
-    local w, h = getSize()
+    local x, y, w, h = getArea()
     local chars = 0
     for line in f:lines() do
       if line:sub(-1) == "\r" then
@@ -584,7 +638,7 @@ do
       table.insert(buffer, line)
       chars = chars + unicode.len(line)
       if #buffer <= h then
-        component.gpu.set(1, #buffer, line)
+        drawLine(x, y, w, h, #buffer)
       end
     end
     f:close()
@@ -607,14 +661,20 @@ end
 
 while running do
   local event, address, arg1, arg2, arg3 = event.pull()
-  if type(address) == "string" and component.isPrimary(address) then
+  local inFocus, screenAddress, keyboardAddress = term.hasFocus()
+  if inFocus and (address == screenAddress or address == keyboardAddress) then
     local blink = true
     if event == "key_down" then
-      onKeyDown(arg1, arg2)
+      onKeyDown(arg1, arg2, keyboardAddress)
     elseif event == "clipboard" and not readonly then
       onClipboard(arg1)
     elseif event == "touch" or event == "drag" then
-      onClick(arg1, arg2)
+      local x, y, w, h = getArea()
+      arg1 = arg1 - x + 1
+      arg2 = arg2 - y + 1
+      if arg1 >= 1 and arg2 >= 1 and arg1 <= w and arg2 <= h then
+        onClick(arg1, arg2)
+      end
     elseif event == "scroll" then
       onScroll(arg3)
     else

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
@@ -1,8 +1,11 @@
-local component = require("component")
 local package = require("package")
 local term = require("term")
 local serialization = require("serialization")
 local shell = require("shell")
+
+local function gpu()
+  return select(2, term.getGPU())
+end
 
 local args, options = shell.parse(...)
 local env = setmetatable({}, {__index = _ENV})
@@ -102,18 +105,18 @@ if #args == 0 or options.i then
     return r2
   end
 
-  component.gpu.setForeground(0xFFFFFF)
+  gpu().setForeground(0xFFFFFF)
   term.write(_VERSION .. " Copyright (C) 1994-2015 Lua.org, PUC-Rio\n")
-  component.gpu.setForeground(0xFFFF00)
+  gpu().setForeground(0xFFFF00)
   term.write("Enter a statement and hit enter to evaluate it.\n")
   term.write("Prefix an expression with '=' to show its value.\n")
   term.write("Press Ctrl+C to exit the interpreter.\n")
-  component.gpu.setForeground(0xFFFFFF)
+  gpu().setForeground(0xFFFFFF)
 
   while term.isAvailable() do
-    local foreground = component.gpu.setForeground(0x00FF00)
+    local foreground = gpu().setForeground(0x00FF00)
     term.write(tostring(env._PROMPT or "lua> "))
-    component.gpu.setForeground(foreground)
+    gpu().setForeground(foreground)
     local command = term.read(history, nil, hint)
     if command == nil then -- eof
       return

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/more.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/more.lua
@@ -1,4 +1,3 @@
-local component = require("component")
 local event = require("event")
 local keyboard = require("keyboard")
 local shell = require("shell")
@@ -20,7 +19,7 @@ end
 
 local line = nil
 local function readlines(num)
-  local w, h = component.gpu.getResolution()
+  local x, y, w, h = term.getGlobalArea()
   num = num or (h - 1)
   term.setCursorBlink(false)
   for _ = 1, num do
@@ -47,7 +46,8 @@ while true do
   end
   while true do
     local event, address, char, code = event.pull("key_down")
-    if component.isPrimary(address) then
+    local hasFocus, screenAddress, keyboardAddress = term.hasFocus()
+    if hasFocus and address == keyboardAddress then
       if code == keyboard.keys.q then
         term.setCursorBlink(false)
         term.clearLine()

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/resolution.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/resolution.lua
@@ -1,10 +1,13 @@
-local component = require("component")
 local shell = require("shell")
 local term = require("term")
 
+local function gpu()
+  return select(2, term.getGPU())
+end
+
 local args = shell.parse(...)
 if #args == 0 then
-  local w, h = component.gpu.getResolution()
+  local w, h = gpu().getResolution()
   io.write(w .. " " .. h)
   return
 end
@@ -21,7 +24,7 @@ if not w or not h then
   return
 end
 
-local result, reason = component.gpu.setResolution(w, h)
+local result, reason = gpu().setResolution(w, h)
 if not result then
   if reason then -- otherwise we didn't change anything
     io.stderr:write(reason)

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
@@ -1,4 +1,3 @@
-local component = require("component")
 local computer = require("computer")
 local event = require("event")
 local fs = require("filesystem")
@@ -9,6 +8,10 @@ local text = require("text")
 local unicode = require("unicode")
 
 -------------------------------------------------------------------------------
+
+local function gpu()
+  return select(2, term.getGPU())
+end
 
 local memoryStream = {}
 
@@ -479,9 +482,9 @@ if #args == 0 and (io.input() == io.stdin or options.i) and not options.c then
       term.clear()
     end
     while term.isAvailable() do
-      local foreground = component.gpu.setForeground(0xFF0000)
+      local foreground = gpu().setForeground(0xFF0000)
       term.write(expand(os.getenv("PS1") or "$ "))
-      component.gpu.setForeground(foreground)
+      gpu().setForeground(foreground)
       local command = term.read(history, nil, hintHandler)
       if not command then
         term.write("exit\n")

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/92_keyboard.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/92_keyboard.lua
@@ -3,26 +3,38 @@ local event = require("event")
 local keyboard = require("keyboard")
 
 local function onKeyDown(_, address, char, code)
-  if component.isPrimary(address) then
-    keyboard.pressedChars[char] = true
-    keyboard.pressedCodes[code] = true
+  if keyboard.pressedChars[address] then
+    keyboard.pressedChars[address][char] = true
+    keyboard.pressedCodes[address][code] = true
   end
 end
 
 local function onKeyUp(_, address, char, code)
-  if component.isPrimary(address) then
-    keyboard.pressedChars[char] = nil
-    keyboard.pressedCodes[code] = nil
+  if keyboard.pressedChars[address] then
+    keyboard.pressedChars[address][char] = nil
+    keyboard.pressedCodes[address][code] = nil
   end
 end
 
-local function onComponentUnavailable(_, componentType)
+local function onComponentAdded(_, address, componentType)
   if componentType == "keyboard" then
-    keyboard.pressedChars = {}
-    keyboard.pressedCodes = {}
+    keyboard.pressedChars[address] = {}
+    keyboard.pressedCodes[address] = {}
   end
+end
+
+local function onComponentRemoved(_, address, componentType)
+  if componentType == "keyboard" then
+    keyboard.pressedChars[address] = nil
+    keyboard.pressedCodes[address] = nil
+  end
+end
+
+for address in component.list("keyboard", true) do
+  onComponentAdded("component_added", address, "keyboard")
 end
 
 event.listen("key_down", onKeyDown)
 event.listen("key_up", onKeyUp)
-event.listen("component_unavailable", onComponentUnavailable)
+event.listen("component_added", onComponentAdded)
+event.listen("component_removed", onComponentRemoved)

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/93_term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/93_term.lua
@@ -1,5 +1,8 @@
+local component = require("component")
 local computer = require("computer")
 local event = require("event")
+local keyboard = require("keyboard")
+local term = require("term")
 
 local gpuAvailable, screenAvailable = false, false
 
@@ -31,5 +34,71 @@ local function onComponentUnavailable(_, componentType)
   end
 end
 
+local function onTermFocus(event, screenAddress)
+  term.__focus[screenAddress] = term.__nextFocus[screenAddress]
+end
+
+local function updateKeyboards(event, _, typ)
+  if event == nil or typ == "screen" or typ == "keyboard" then
+    term.__keyboardToScreen = {}
+    term.__screenToKeyboard = {}
+    for screenAddress in component.list("screen", true) do
+      local keyboardAddress = component.invoke(screenAddress, "getKeyboards")[1]
+      if keyboardAddress then
+        term.__keyboardToScreen[keyboardAddress] = screenAddress
+        term.__screenToKeyboard[screenAddress] = keyboardAddress
+      end
+    end
+  end
+end
+
+local function onKeyDown(event, keyboardAddress, char, code)
+  local screenAddress = term.__keyboardToScreen[keyboardAddress]
+  if screenAddress then
+    local self = term.__focus[screenAddress]
+    if self then
+      if code == keyboard.keys.tab then
+        if keyboard.isControlDown(keyboardAddress) then
+          if keyboard.isShiftDown(keyboardAddress) then
+            self:focusPrevious()
+          else
+            self:focusNext()
+          end
+        end
+      end
+    end
+  end
+end
+
+local function onTouch(event, screenAddress, x, y)
+  local list = term.__knownWindows[screenAddress]
+  if list[1] then
+    local _, gpu = list[1]:getGPU()
+    if gpu and gpu.getScreen() == screenAddress then
+      local w, h = gpu.getResolution()
+      if w then
+        local nextWindow
+        for _, window in ipairs(list) do
+          local xWin, yWin, wWin, hWin = window:getGlobalArea(w, h)
+          local xOffset, yOffset = x - xWin, y - yWin
+          if xOffset >= 0 and xOffset < wWin and yOffset >= 0 and yOffset < hWin then
+            nextWindow = window
+          end
+        end
+        if nextWindow then
+          nextWindow:focus()
+        end
+      end
+    end
+  end
+end
+
 event.listen("component_available", onComponentAvailable)
 event.listen("component_unavailable", onComponentUnavailable)
+event.listen("component_added", updateKeyboards)
+event.listen("component_removed", updateKeyboards)
+event.listen("term_focus", onTermFocus)
+event.listen("key_down", onKeyDown)
+event.listen("touch", onTouch)
+
+

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/event.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/event.lua
@@ -185,11 +185,9 @@ function event.pullFiltered(...)
     filter = args[2]
   end
 
-  local deadline = seconds and
-                   (computer.uptime() + seconds) or
-                   (filter and math.huge or 0)
+  local deadline = seconds and (computer.uptime() + seconds) or math.huge
   repeat
-    local closest = seconds and deadline or math.huge
+    local closest = deadline
     for _, timer in pairs(timers) do
       closest = math.min(closest, timer.after)
     end
@@ -207,8 +205,10 @@ function event.pullFiltered(...)
       lastInterrupt = computer.uptime()
       return "interrupted", awaited
     end
-    if not (seconds or filter) or filter == nil or filter(table.unpack(signal, 1, signal.n)) then
-      return table.unpack(signal, 1, signal.n)
+    if signal.n > 0 then
+      if not (seconds or filter) or filter == nil or filter(table.unpack(signal, 1, signal.n)) then
+        return table.unpack(signal, 1, signal.n)
+      end
     end
   until computer.uptime() >= deadline
 end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/keyboard.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/keyboard.lua
@@ -1,3 +1,5 @@
+local component = require("component")
+
 local keyboard = {pressedChars = {}, pressedCodes = {}}
 
 keyboard.keys = {
@@ -144,29 +146,59 @@ end
 
 -------------------------------------------------------------------------------
 
-function keyboard.isAltDown()
-  return (keyboard.pressedCodes[keyboard.keys.lmenu] or keyboard.pressedCodes[keyboard.keys.rmenu]) ~= nil
+local function getKeyboardAddress(address)
+  if address then
+    return address
+  else
+    local primary = component.isAvailable("keyboard") and component.getPrimary("keyboard")
+    if primary then
+      return primary.address
+    end
+  end
+end
+
+local function getPressedCodes(address)
+  address = getKeyboardAddress(address)
+  return address and keyboard.pressedCodes[address] or false
+end
+
+local function getPressedChars(address)
+  address = getKeyboardAddress(address)
+  return address and keyboard.pressedChars[address] or false
+end
+
+function keyboard.isAltDown(address)
+  checkArg(1, address, "string", "nil")
+  local pressedCodes = getPressedCodes(address)
+  return pressedCodes and (pressedCodes[keyboard.keys.lmenu] or pressedCodes[keyboard.keys.rmenu]) ~= nil
 end
 
 function keyboard.isControl(char)
   return type(char) == "number" and (char < 0x20 or (char >= 0x7F and char <= 0x9F))
 end
 
-function keyboard.isControlDown()
-  return (keyboard.pressedCodes[keyboard.keys.lcontrol] or keyboard.pressedCodes[keyboard.keys.rcontrol]) ~= nil
+function keyboard.isControlDown(address)
+  checkArg(1, address, "string", "nil")
+  local pressedCodes = getPressedCodes(address)
+  return pressedCodes and (pressedCodes[keyboard.keys.lcontrol] or pressedCodes[keyboard.keys.rcontrol]) ~= nil
 end
 
-function keyboard.isKeyDown(charOrCode)
+function keyboard.isKeyDown(charOrCode, address)
   checkArg(1, charOrCode, "string", "number")
+  checkArg(2, address, "string", "nil")
   if type(charOrCode) == "string" then
-    return keyboard.pressedChars[utf8 and utf8.codepoint(charOrCode) or charOrCode:byte()]
+    local pressedChars = getPressedChars(address)
+    return pressedChars and pressedChars[utf8 and utf8.codepoint(charOrCode) or charOrCode:byte()]
   elseif type(charOrCode) == "number" then
-    return keyboard.pressedCodes[charOrCode]
+    local pressedCodes = getPressedCodes(address)
+    return pressedCodes and pressedCodes[charOrCode]
   end
 end
 
-function keyboard.isShiftDown()
-  return (keyboard.pressedCodes[keyboard.keys.lshift] or keyboard.pressedCodes[keyboard.keys.rshift]) ~= nil
+function keyboard.isShiftDown(address)
+  checkArg(1, address, "string", "nil")
+  local pressedCodes = getPressedCodes(address)
+  return pressedCodes and (pressedCodes[keyboard.keys.lshift] or pressedCodes[keyboard.keys.rshift]) ~= nil
 end
 
 -------------------------------------------------------------------------------

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -6,105 +6,350 @@ local text = require("text")
 local unicode = require("unicode")
 
 local term = {}
-local cursorX, cursorY = 1, 1
-local cursorBlink = nil
+local methods = {}
 
-local function toggleBlink()
-  if term.isAvailable() then
-    cursorBlink.state = not cursorBlink.state
-    if cursorBlink.state then
-      cursorBlink.alt = component.gpu.get(cursorX, cursorY) or cursorBlink.alt
-      component.gpu.set(cursorX, cursorY, string.rep(unicode.char(0x2588), unicode.charWidth(cursorBlink.alt))) -- solid block
-    else
-      component.gpu.set(cursorX, cursorY, cursorBlink.alt)
+local validateFocus
+local metatable = {
+  __index = methods,
+  __gc = function(self)
+    self:setCursorBlink(false)
+  end,
+  __pairs = function(self)
+    return function(_, k)
+      return next(methods, k)
+    end, self, nil
+  end,
+  __gc = function(self)
+    validateFocus(self, nil)
+  end,
+}
+
+--allows collection of windows with enabled cursor blink
+--timer id -> window
+term.__blinking = setmetatable({}, {__mode = "v"})
+
+--screen address -> window
+term.__focus = setmetatable({}, {__mode = "v"})
+term.__nextFocus = setmetatable({}, {__mode = "v"})
+--window -> screen address
+term.__usedScreen = setmetatable({}, {__mode = "k"})
+--
+term.__knownWindows = setmetatable({}, {
+  __mode = "v",
+  __index = function(t, k)
+    local v = setmetatable({}, {__mode = "v"})
+    t[k] = v
+    return v
+  end,
+})
+
+local function register(self, address)
+  local state = self.__state
+  if address then
+    state.neighbors = term.__knownWindows[address]
+    table.insert(state.neighbors, self)
+  else
+    state.neighbors = {self}
+  end
+end
+
+local function unregister(self, address)
+  local state = self.__state
+  local i, n = 1, #state.neighbors
+  for i = 1, n do
+    if state.neighbors[i] == self then
+      table.remove(state.neighbors, i)
+      break
+    end
+  end
+  state.neighbors = nil
+end
+
+local function setFocus(self, screenAddress)
+  if screenAddress and term.__focus[screenAddress] ~= self and term.__nextFocus[screenAddress] ~= self then
+    term.__focus[screenAddress] = nil
+    term.__nextFocus[screenAddress] = self
+    computer.pushSignal("term_focus", screenAddress)
+  end
+end
+
+validateFocus = function(self, address)
+  local oldAddress = term.__usedScreen[self]
+  if oldAddress ~= address then
+    self:unfocus()
+    unregister(self, oldAddress)
+    term.__usedScreen[self] = address
+    register(self, address)
+  end
+  if address then
+    if term.__focus[address] == nil and term.__nextFocus[address] == nil then
+      setFocus(self, address)
     end
   end
 end
+
+local function gpu(self)
+  local state = self.__state
+  return state.gpu or (component.isAvailable("gpu") and component.gpu) or nil
+end
+
+local function getScreenAddress(self)
+  if gpu(self) then
+    local ok, address = pcall(gpu(self).getScreen)
+    if ok then
+      validateFocus(self, address)
+      return address
+    end
+    validateFocus(self, nil)
+  end
+end
+
+local function toggleBlink(self)
+  local state = self.__state
+  local cursorBlink = state.cursorBlink
+  local screenAddress = getScreenAddress(self)
+  if screenAddress then
+    local currentFocus = term.__focus[screenAddress]
+    local isInFocus = (currentFocus == self or currentFocus == nil)
+    cursorBlink.state = not cursorBlink.state
+    local x, y, w, h = self:getGlobalArea()
+    local cursorX, cursorY = state.cursorX, state.cursorY
+    if cursorX < 1 or cursorY < 1 or cursorX > w or cursorY > h then
+      return
+    end
+    local xAbs, yAbs = x + cursorX - 1, y + cursorY - 1
+    if cursorBlink.state then
+      local char = isInFocus and unicode.char(0x2588) or unicode.char(0x2592) -- solid block or medium shade
+      cursorBlink.alt = gpu(self).get(xAbs, yAbs) or cursorBlink.alt
+      gpu(self).set(xAbs, yAbs, string.rep(char, unicode.charWidth(cursorBlink.alt)))
+    else
+      gpu(self).set(xAbs, yAbs, cursorBlink.alt)
+    end
+  end
+end
+
+term.__keyboardToScreen = {}
+term.__screenToKeyboard = {}
 
 -------------------------------------------------------------------------------
 
-function term.clear()
-  if term.isAvailable() then
-    local w, h = component.gpu.getResolution()
-    component.gpu.fill(1, 1, w, h, " ")
+function term.newWindow(x, y, width, height, gpu)
+  checkArg(1, x, "number", "nil")
+  checkArg(2, y, "number", "nil")
+  checkArg(3, width, "number", "nil")
+  checkArg(4, height, "number", "nil")
+  checkArg(5, gpu, "table", "nil")
+  local window = setmetatable({}, metatable)
+  window.__state = {
+    x = x or 1,
+    y = y or 1,
+    width = width or -1,
+    height = height or -1,
+    gpu = gpu,
+    cursorX = 1, cursorY = 1,
+    cursorBlink = nil,
+    neighbors = {window},
+  }
+  return window
+end
+
+local defaultWindow = term.newWindow()
+
+function term.setWindow(newWindow)
+  checkArg(1, newWindow, "table")
+  local info = require("process").info()
+  local oldWindow
+  if info then
+    local data = info.data
+    oldWindow = data.term_window
+    data.term_window = newWindow
+  else
+    oldWindow = defaultWindow
+    defaultWindow = newWindow
   end
-  cursorX, cursorY = 1, 1
+  return oldWindow
 end
 
-function term.reset()
-  if term.isAvailable() then
-    local maxw, maxh = component.gpu.maxResolution()
-    component.gpu.setResolution(maxw, maxh)
-    component.gpu.setBackground(0x000000)
-    component.gpu.setForeground(0xFFFFFF)
-    term.clear()
+function term.getWindow()
+  local info = require("process").info()
+  if info then
+    local data = info.data
+    if data.term_window then
+      return data.term_window
+    end
+  end
+  return defaultWindow
+end
+
+
+function methods:setArea(x, y, width, height)
+  checkArg(1, x, "number")
+  checkArg(2, y, "number")
+  checkArg(3, width, "number")
+  checkArg(4, height, "number")
+  assert(x ~= 0 and y ~= 0 and width ~= 0 and height ~= 0, "Nonzero arguments only!")
+  
+  local state = self.__state
+  local oldX, oldY, oldWidth, oldHeight = state.x, state.y, state.width, state.height
+  state.x, state.y, state.width, state.height = x, y, width, height
+  return oldX, oldY, oldWidth, oldHeight
+end
+
+function methods:getArea()
+  local state = self.__state
+  return state.x, state.y, state.width, state.height
+end
+
+function methods:setGPU(newGPU)
+  local state = self.__state
+  local oldGPU = state.gpu
+  state.gpu = newGPU
+  return oldGPU
+end
+
+function methods:getGPU()
+  local state = self.__state
+  return state.gpu, gpu(self)
+end
+
+local function getAbsolute(pos, size)
+  if pos < 0 then
+    pos = size + pos + 1
+  end
+  return math.min(math.max(pos, 1), size)
+end
+
+function methods:getGlobalArea(w, h)
+  checkArg(1, w, "number", "nil")
+  checkArg(2, h, "number", "nil")
+  local state = self.__state
+  if not w or not h then
+    if gpu(self) then
+      w, h = gpu(self).getResolution()
+      validateFocus(self, gpu(self).getScreen())
+    end
+  end
+  if not w then
+    return
+  end
+  local x, y = getAbsolute(state.x, w), getAbsolute(state.y, h)
+  local wMax, hMax = w - x + 1, h - y + 1
+  return x, y, getAbsolute(state.width, wMax), getAbsolute(state.height, hMax)
+end
+
+
+function methods:toGlobal(x, y)
+  checkArg(1, x, "number")
+  checkArg(2, y, "number")
+  local dx, dy = self:getGlobalArea()
+  if dx then
+    return x + dx - 1, y + dy - 1
+  end
+end
+function methods:toLocal(x, y)
+  checkArg(1, x, "number")
+  checkArg(2, y, "number")
+  local dx, dy = self:getGlobalArea()
+  if dx then
+    return x - dx + 1, y - dy + 1
   end
 end
 
-function term.clearLine()
-  if term.isAvailable() then
-    local w = component.gpu.getResolution()
-    component.gpu.fill(1, cursorY, w, 1, " ")
+function methods:clear()
+  local state = self.__state
+  local x, y, w, h = self:getGlobalArea()
+  if x then
+    gpu(self).fill(x, y, w, h, " ")
   end
-  cursorX = 1
+  state.cursorX, state.cursorY = 1, 1
 end
 
-function term.getCursor()
-  return cursorX, cursorY
+function methods:reset()
+  if self:isAvailable() then
+    local maxw, maxh = gpu(self).maxResolution()
+    gpu(self).setResolution(maxw, maxh)
+    gpu(self).setBackground(0x000000)
+    gpu(self).setForeground(0xFFFFFF)
+    self:clear()
+  end
 end
 
-function term.setCursor(col, row)
+function methods:clearLine()
+  local state = self.__state
+  local x, y, w, h = self:getGlobalArea()
+  if x then
+    gpu(self).fill(x, state.cursorY + y - 1, w, 1, " ")
+  end
+  state.cursorX = 1
+end
+
+function methods:getCursor()
+  local state = self.__state
+  return state.cursorX, state.cursorY
+end
+
+function methods:setCursor(col, row)
   checkArg(1, col, "number")
   checkArg(2, row, "number")
+  local state = self.__state
+  local cursorBlink = state.cursorBlink
   if cursorBlink and cursorBlink.state then
-    toggleBlink()
+    toggleBlink(self)
   end
-  local wide, right = term.isWide(cursorX, cursorY)
+  state.cursorX = math.floor(col)
+  state.cursorY = math.floor(row)
+  local wide, right = self:isWide(state.cursorX, state.cursorY)
   if wide and right then
-    cursorX = cursorX - 1
+    state.cursorX = state.cursorX - 1
   end
-  cursorX = math.floor(col)
-  cursorY = math.floor(row)
 end
 
-function term.getCursorBlink()
-  return cursorBlink ~= nil
+function methods:getCursorBlink()
+  local state = self.__state
+  return state.cursorBlink ~= nil
 end
 
-function term.setCursorBlink(enabled)
+function methods:setCursorBlink(enabled)
   checkArg(1, enabled, "boolean")
+  local state = self.__state
+  local cursorBlink = state.cursorBlink
   if enabled then
     if not cursorBlink then
       cursorBlink = {}
-      cursorBlink.id = event.timer(0.5, toggleBlink, math.huge)
+      cursorBlink.id = event.timer(0.5, function() toggleBlink(term.__blinking[cursorBlink.id]) end, math.huge)
+      term.__blinking[cursorBlink.id] = self
       cursorBlink.state = false
     elseif not cursorBlink.state then
-      toggleBlink()
+      toggleBlink(self)
     end
   elseif cursorBlink then
+    term.__blinking[cursorBlink.id] = nil
     event.cancel(cursorBlink.id)
     if cursorBlink.state then
-      toggleBlink()
+      toggleBlink(self)
     end
     cursorBlink = nil
   end
+  state.cursorBlink = cursorBlink
 end
 
-function term.isWide(x, y)
-  if not term.isAvailable() then
+function methods:isWide(x, y)
+  local xWin, yWin, wWin, hWin = self:getGlobalArea()
+  if xWin == nil then
     return false
   end
-  local w, h = component.gpu.getResolution()
-  if x < 1 or x > w or y < 1 or y > h then
+  if x < 1 or x > wWin or y < 1 or y > hWin then
     return false
   end
-  local char = component.gpu.get(x, y)
+  x = x + xWin - 1
+  y = y + yWin - 1
+  local char = gpu(self).get(x, y)
   if unicode.isWide(char) then
     -- The char at the specified position is a wide char.
     return true
   end
-  if char == " " and x > 1 then
-    local charLeft = component.gpu.get(x - 1, y)
+  if char == " " and x > xWin then
+    local charLeft = gpu(self).get(x - 1, y)
     if charLeft and unicode.isWide(charLeft) then
       -- The char left to the specified position is a wide char.
       return true, true
@@ -114,27 +359,80 @@ function term.isWide(x, y)
   return false
 end
 
-function term.isAvailable()
-  if component.isAvailable("gpu") and component.isAvailable("screen") then
-    -- Ensure our primary GPU is bound to our primary screen.
-    if component.gpu.getScreen() ~= component.screen.address then
-      component.gpu.bind(component.screen.address)
-    end
+function methods:isAvailable()
+  if getScreenAddress(self) then
     return true
   end
   return false
 end
 
-function term.read(history, dobreak, hint, pwchar, filter)
+function methods:focus()
+  setFocus(self, getScreenAddress(self))
+end
+
+function methods:unfocus()
+  local screenAddress = term.__usedScreen[self]
+  if screenAddress then
+    if term.__focus[screenAddress] == self or term.__nextFocus[screenAddress] == self then
+      term.__focus[screenAddress] = nil
+      term.__nextFocus[screenAddress] = nil
+      self:focusNext()
+    end
+  end
+end
+
+function methods:focusNext()
+  local state = self.__state
+  local i, n = 1, #state.neighbors
+  if n > 1 then
+    for i = 1, n do
+      if state.neighbors[i] == self then
+        state.neighbors[(i % n) + 1]:focus()
+        break
+      end
+    end
+  end
+end
+
+function methods:focusPrevious()
+  local state = self.__state
+  local i, n = 1, #state.neighbors
+  if n > 1 then
+    for i = 1, n do
+      if state.neighbors[i] == self then
+        state.neighbors[((i - 2) % n) + 1]:focus()
+        break
+      end
+    end
+  end
+end
+
+function methods:hasFocus(screenAddress)
+  checkArg(1, screenAddress, "string", "nil")
+  screenAddress = screenAddress or getScreenAddress(self)
+  local keyboardAddress
+  if screenAddress then
+    keyboardAddress = term.__screenToKeyboard[screenAddress]
+    if term.__focus[screenAddress] == self then
+      return true, screenAddress, keyboardAddress
+    end
+  end
+  return false, screenAddress, keyboardAddress
+end
+
+function methods:read(history, dobreak, hint, pwchar, filter)
   checkArg(1, history, "table", "nil")
   checkArg(3, hint, "function", "table", "nil")
   checkArg(4, pwchar, "string", "nil")
   checkArg(5, filter, "string", "function", "nil")
   history = history or {}
   table.insert(history, "")
-  local offset = term.getCursor() - 1
-  local scrollX, scrollY = 0, #history - 1
-  local cursorX = 1
+
+  local state = self.__state
+  local offset = self:getCursor() - 1
+  local scrollX = 0
+  local textCursorX = 1
+  local historyIndex = #history
 
   if type(hint) == "table" then
     local hintTable = hint
@@ -143,6 +441,7 @@ function term.read(history, dobreak, hint, pwchar, filter)
     end
   end
   local hintCache, hintIndex
+  local redraw
 
   if pwchar and unicode.len(pwchar) > 0 then
     pwchar = unicode.sub(pwchar, 1, 1)
@@ -159,108 +458,103 @@ function term.read(history, dobreak, hint, pwchar, filter)
     return pwchar and pwchar:rep(unicode.len(str)) or str
   end
 
-  local function getCursor()
-    return cursorX, 1 + scrollY
+  local function getTextCursor()
+    return textCursorX
+  end
+  
+  local function getHistoryIndex()
+    return historyIndex
+  end
+  
+  local function setHistoryIndex(newIndex)
+    historyIndex = newIndex
   end
 
   local function line()
-    local _, cby = getCursor()
-    return history[cby]
+    return history[getHistoryIndex()]
   end
 
   local function clearHint()
     hintCache = nil
   end
 
-  local function setCursor(nbx, nby)
-    local w, h = component.gpu.getResolution()
-    local cx, cy = term.getCursor()
-
-    scrollY = nby - 1
-
-    nbx = math.max(1, math.min(unicode.len(history[nby]) + 1, nbx))
-    local ncx = nbx + offset - scrollX
-    if ncx > w then
-      local sx = nbx - (w - offset)
-      local dx = math.abs(scrollX - sx)
-      scrollX = sx
-      component.gpu.copy(1 + offset + dx, cy, w - offset - dx, 1, -dx, 0)
-      local str = masktext(unicode.sub(history[nby], nbx - (dx - 1), nbx))
-      str = text.padRight(str, dx)
-      component.gpu.set(1 + math.max(offset, w - dx), cy, unicode.sub(str, 1 + math.max(0, dx - (w - offset))))
-    elseif ncx < 1 + offset then
-      local sx = nbx - 1
-      local dx = math.abs(scrollX - sx)
-      scrollX = sx
-      component.gpu.copy(1 + offset, cy, w - offset - dx, 1, dx, 0)
-      local str = masktext(unicode.sub(history[nby], nbx, nbx + dx))
-      --str = text.padRight(str, dx)
-      component.gpu.set(1 + offset, cy, str)
+  local function setTextCursor(newCursor)
+    local x, y, w, h = self:getGlobalArea()
+    local termCursorX, termCursorY = self:getCursor()
+    local str = line() .. " "
+    
+    textCursorX = math.max(1, math.min(unicode.len(str), newCursor))
+    
+    while offset + unicode.wlen(unicode.sub(str, 1 + scrollX, textCursorX)) > w do
+      scrollX = scrollX + 1
     end
-
-    cursorX = nbx
-    term.setCursor(nbx - scrollX + offset, cy)
+    if textCursorX <= scrollX then
+      scrollX = textCursorX - 1
+    end
+    termCursorX = offset + unicode.wlen(unicode.sub(str, 1 + scrollX, textCursorX - 1)) + 1
+    
+    self:setCursor(termCursorX, termCursorY)
+    redraw()
     clearHint()
   end
 
   local function copyIfNecessary()
-    local cbx, cby = getCursor()
-    if cby ~= #history then
+    local index = getHistoryIndex()
+    if index ~= #history then
       history[#history] = line()
-      setCursor(cbx, #history)
+      setHistoryIndex(#history)
     end
   end
 
-  local function redraw()
-    local cx, cy = term.getCursor()
-    local bx, by = 1 + scrollX, 1 + scrollY
-    local w, h = component.gpu.getResolution()
+  redraw = function()
+    local _, termCursorY = self:getCursor()
+    local x, y, w, h = self:getGlobalArea()
     local l = w - offset
-    local str = masktext(unicode.sub(history[by], bx, bx + l))
+    local str = history[getHistoryIndex()]
+    str = masktext(unicode.sub(str, scrollX + 1, scrollX + l))
+    str = (unicode.wlen(str) > l) and unicode.wtrunc(str, l + 1) or str
     str = text.padRight(str, l)
-    component.gpu.set(1 + offset, cy, str)
+    gpu(self).set(x + offset, termCursorY + y - 1, str)
   end
 
   local function home()
-    local cbx, cby = getCursor()
-    setCursor(1, cby)
+    setTextCursor(1)
   end
 
   local function ende()
-    local cbx, cby = getCursor()
-    setCursor(unicode.len(line()) + 1, cby)
+    setTextCursor(unicode.len(line()) + 1)
   end
 
   local function left()
-    local cbx, cby = getCursor()
-    if cbx > 1 then
-      setCursor(cbx - 1, cby)
+    local cursorX = getTextCursor()
+    if cursorX > 1 then
+      setTextCursor(cursorX - 1)
       return true -- for backspace
     end
   end
 
   local function right(n)
     n = n or 1
-    local cbx, cby = getCursor()
-    local be = unicode.len(line()) + 1
-    if cbx < be then
-      setCursor(math.min(be, cbx + n), cby)
+    local cursorX = getTextCursor()
+    local maxX = unicode.len(line()) + 1
+    if cursorX < maxX then
+      setTextCursor(math.min(maxX, cursorX + n))
     end
   end
 
   local function up()
-    local cbx, cby = getCursor()
-    if cby > 1 then
-      setCursor(1, cby - 1)
+    local index = getHistoryIndex()
+    if index > 1 then
+      setHistoryIndex(index - 1)
       redraw()
       ende()
     end
   end
 
   local function down()
-    local cbx, cby = getCursor()
-    if cby < #history then
-      setCursor(1, cby + 1)
+    local index = getHistoryIndex()
+    if index < #history then
+      setHistoryIndex(index + 1)
       redraw()
       ende()
     end
@@ -269,45 +563,31 @@ function term.read(history, dobreak, hint, pwchar, filter)
   local function delete()
     copyIfNecessary()
     clearHint()
-    local cbx, cby = getCursor()
-    if cbx <= unicode.len(line()) then
-      local cw = unicode.charWidth(unicode.sub(line(), cbx))
-      history[cby] = unicode.sub(line(), 1, cbx - 1) ..
-                     unicode.sub(line(), cbx + 1)
-      local cx, cy = term.getCursor()
-      local w, h = component.gpu.getResolution()
-      component.gpu.copy(cx + cw, cy, w - cx, 1, -cw, 0)
-      local br = cbx + (w - cx)
-      local char = masktext(unicode.sub(line(), br, br))
-      if not char or unicode.wlen(char) == 0 then
-        char = " "
-      end
-      component.gpu.set(w, cy, char)
+    local cursorX = getTextCursor()
+    local index = getHistoryIndex()
+    if cursorX <= unicode.len(line()) then
+      history[index] = unicode.sub(line(), 1, cursorX - 1) ..
+                       unicode.sub(line(), cursorX + 1)
+      redraw()
     end
   end
 
   local function insert(value)
     copyIfNecessary()
     clearHint()
-    local cx, cy = term.getCursor()
-    local cbx, cby = getCursor()
-    local w, h = component.gpu.getResolution()
-    history[cby] = unicode.sub(line(), 1, cbx - 1) ..
-                   value ..
-                   unicode.sub(line(), cbx)
-    local len = unicode.wlen(value)
-    local n = w - (cx - 1) - len
-    if n > 0 then
-      component.gpu.copy(cx, cy, n, 1, len, 0)
-    end
-    component.gpu.set(cx, cy, masktext(value))
+    local cursorX = getTextCursor()
+    local index = getHistoryIndex()
+    history[index] = unicode.sub(line(), 1, cursorX - 1) ..
+                     value ..
+                     unicode.sub(line(), cursorX)
     right(unicode.len(value))
   end
 
   local function tab(direction)
-    local cbx, cby = getCursor()
+    local cursorX = getTextCursor()
+    local historyIndex = getHistoryIndex()
     if not hintCache then -- hint is never nil, see onKeyDown
-      hintCache = hint(line(), cbx)
+      hintCache = hint(line(), cursorX)
       hintIndex = 0
       if type(hintCache) == "string" then
         hintCache = {hintCache}
@@ -318,7 +598,7 @@ function term.read(history, dobreak, hint, pwchar, filter)
     end
     if hintCache then
       hintIndex = (hintIndex + direction + #hintCache - 1) % #hintCache + 1
-      history[cby] = tostring(hintCache[hintIndex])
+      history[historyIndex] = tostring(hintCache[hintIndex])
       -- because all other cases of the cursor being moved will result
       -- in the hint cache getting invalidated we do that in setCursor,
       -- so we have to back it up here to restore it after moving.
@@ -331,8 +611,8 @@ function term.read(history, dobreak, hint, pwchar, filter)
     end
   end
 
-  local function onKeyDown(char, code)
-    term.setCursorBlink(false)
+  local function onKeyDown(keyboardAddress, char, code)
+    self:setCursorBlink(false)
     if code == keyboard.keys.back then
       if left() then delete() end
     elseif code == keyboard.keys.delete then
@@ -349,20 +629,22 @@ function term.read(history, dobreak, hint, pwchar, filter)
       up()
     elseif code == keyboard.keys.down then
       down()
-    elseif code == keyboard.keys.tab and hint then
-      tab(keyboard.isShiftDown() and -1 or 1)
+    elseif code == keyboard.keys.tab then
+      if not keyboard.isControlDown(keyboardAddress) and hint then
+        tab(keyboard.isShiftDown(keyboardAddress) and -1 or 1)
+      end
     elseif code == keyboard.keys.enter then
       if not filter or filter(line() or "") then
-        local cbx, cby = getCursor()
-        if cby ~= #history then -- bring entry to front
+        local index = getHistoryIndex()
+        if index ~= #history then -- bring entry to front
           history[#history] = line()
-          table.remove(history, cby)
+          table.remove(history, index)
         end
         return true, history[#history] .. "\n"
       else
         computer.beep(2000, 0.1)
       end
-    elseif keyboard.isControlDown() and code == keyboard.keys.d then
+    elseif keyboard.isControlDown(keyboardAddress) and code == keyboard.keys.d then
       if line() == "" then
         history[#history] = ""
         return true, nil
@@ -370,24 +652,41 @@ function term.read(history, dobreak, hint, pwchar, filter)
     elseif not keyboard.isControl(char) then
       insert(unicode.char(char))
     end
-    term.setCursorBlink(true)
-    term.setCursorBlink(true) -- force toggle to caret
+    self:setCursorBlink(true)
+    self:setCursorBlink(true) -- force toggle to caret
   end
 
   local function onClipboard(value)
     copyIfNecessary()
-    term.setCursorBlink(false)
-    local cbx, cby = getCursor()
+    self:setCursorBlink(false)
+    local cursorX = getTextCursor()
+    local index = getHistoryIndex()
     local l = value:find("\n", 1, true)
     if l then
-      history[cby] = unicode.sub(line(), 1, cbx - 1)
+      history[index] = unicode.sub(line(), 1, cursorX - 1)
       redraw()
       insert(unicode.sub(value, 1, l - 1))
       return true, line() .. "\n"
     else
       insert(value)
-      term.setCursorBlink(true)
-      term.setCursorBlink(true) -- force toggle to caret
+      self:setCursorBlink(true)
+      self:setCursorBlink(true) -- force toggle to caret
+    end
+  end
+  
+  local function onTouch(x, y)
+    local xWin, yWin, wWin, hWin = self:getGlobalArea()
+    x = x - xWin + 1
+    y = y - yWin + 1
+    if x > 0 and y > 0 and x <= wWin and y <= hWin then
+      local _, termCursorY = self:getCursor()
+      if y == termCursorY and x > offset then
+        local l = wWin - offset
+        local str = history[getHistoryIndex()]
+        str = masktext(unicode.sub(str, scrollX + 1, scrollX + l))
+        str = (unicode.wlen(str) >= x - offset) and unicode.wtrunc(str, x - offset) or str
+        setTextCursor(scrollX + 1 + unicode.len(str))
+      end
     end
   end
 
@@ -395,16 +694,15 @@ function term.read(history, dobreak, hint, pwchar, filter)
     if history[#history] == "" then
       table.remove(history)
     end
-    term.setCursorBlink(false)
-    if term.getCursor() > 1 and dobreak ~= false then
-      term.write("\n")
+    self:setCursorBlink(false)
+    if self:getCursor() > 1 and dobreak ~= false then
+      self:write("\n")
     end
   end
 
-  term.setCursorBlink(true)
-  while term.isAvailable() do
-    local ocx, ocy = getCursor()
-    local ok, name, address, charOrValue, code = pcall(event.pull)
+  self:setCursorBlink(true)
+  while self:isAvailable() do
+    local ok, name, address, charOrValueOrX, codeOrY = pcall(event.pull)
     if not ok then
       cleanup()
       error("interrupted", 0)
@@ -413,21 +711,24 @@ function term.read(history, dobreak, hint, pwchar, filter)
       cleanup()
       return nil
     end
-    local ncx, ncy = getCursor()
-    if ocx ~= ncx or ocy ~= ncy then
-      cleanup()
-      return "" -- soft fail the read if someone messes with the term
-    end
-    if term.isAvailable() and -- may have changed since pull
-       type(address) == "string" and
-       component.isPrimary(address)
-    then
+    local isInFocus, screenAddress, keyboardAddress = self:hasFocus()
+    --screen may have changed since pull
+    if isInFocus and type(address) == "string" then
       local done, result
-      if name == "key_down" then
-        done, result = onKeyDown(charOrValue, code)
-      elseif name == "clipboard" then
-        done, result = onClipboard(charOrValue)
+      if address == screenAddress then
+        if name == "touch" then
+          done, result = onTouch(charOrValueOrX, codeOrY)
+        end
+      elseif address == keyboardAddress then
+        if isInFocus then
+          if name == "key_down" then
+            done, result = onKeyDown(address, charOrValueOrX, codeOrY)
+          elseif name == "clipboard" then
+            done, result = onClipboard(charOrValueOrX)
+          end
+        end
       end
+
       if done then
         cleanup()
         return result
@@ -438,10 +739,11 @@ function term.read(history, dobreak, hint, pwchar, filter)
   return nil -- fail the read if term becomes unavailable
 end
 
-function term.write(value, wrap)
-  if not term.isAvailable() then
+function methods:write(value, wrap)
+  if not self:isAvailable() then
     return
   end
+  value = text:gsub("\0", "")
   value = text.detab(tostring(value))
   if unicode.wlen(value) == 0 then
     return
@@ -453,34 +755,47 @@ function term.write(value, wrap)
       computer.beep()
     end
   end
-  local w, h = component.gpu.getResolution()
+  local x, y, w, h = self:getGlobalArea()
   if not w then
     return -- gpu lost its screen but the signal wasn't processed yet.
   end
-  local blink = term.getCursorBlink()
-  term.setCursorBlink(false)
+  local blink = self:getCursorBlink()
+  local state = self.__state
+  self:setCursorBlink(false)
   local line, nl
   repeat
+    local remainingWidth = w - (state.cursorX - 1)
     local wrapAfter, margin = math.huge, math.huge
     if wrap then
-      wrapAfter, margin = w - (cursorX - 1), w
+      wrapAfter, margin = remainingWidth, w
     end
     line, value, nl = text.wrap(value, wrapAfter, margin)
-    component.gpu.set(cursorX, cursorY, line)
-    cursorX = cursorX + unicode.wlen(line)
-    if nl or (cursorX > w and wrap) then
-      cursorX = 1
-      cursorY = cursorY + 1
+    line = (unicode.wlen(line) > remainingWidth) and unicode.wtrunc(line, remainingWidth + 1) or line
+    gpu(self).set(state.cursorX + x - 1, state.cursorY + y - 1, line)
+    state.cursorX = state.cursorX + unicode.wlen(line)
+    if nl or (state.cursorX > w and wrap) then
+      state.cursorX = 1
+      state.cursorY = state.cursorY + 1
     end
-    if cursorY > h then
-      component.gpu.copy(1, 1, w, h, 0, -1)
-      component.gpu.fill(1, h, w, 1, " ")
-      cursorY = h
+    if state.cursorY > h then
+      gpu(self).copy(x, y + 1, w, h - 1, 0, -1)
+      gpu(self).fill(x, h + y - 1, w, 1, " ")
+      state.cursorY = h
     end
   until not value
-  term.setCursorBlink(blink)
+  self:setCursorBlink(blink)
 end
 
 -------------------------------------------------------------------------------
+
+--Automaticly generate term library functions from window methods
+for k, v in pairs(methods) do
+  if type(v) == "function" then
+    term[k] = function(...)
+      local self = term.getWindow()
+      return self[k](self, ...)
+    end
+  end
+end
 
 return term


### PR DESCRIPTION
A crude but working test program:
`wget 'https://raw.githubusercontent.com/mpmxyz/ocprograms/dev/home/bin/split.lua'`
Some programs have to be modified to support term windows properly. (e.g. to use term.getGlobalArea instead of gpu.getResolution)
I'd do that in a next step.

You can change the focus between term windows by using Ctrl [+ Shift] + Tab
Screenshots of the change:
https://raw.githubusercontent.com/mpmxyz/ocprograms/dev/pics/multiscreen1.png
https://raw.githubusercontent.com/mpmxyz/ocprograms/dev/pics/multiscreen2.png

API changes
- keyboard
  - changed
    - isAltDown, isControlDown, isKeyDown, isShiftDown
      - added optional 'address' parameter to specify the keyboard being used
      - defaults to the address of the primary keyboard
- term
  - added
    - term.newWindow([x:number, y:number, width:number, height:number, gpu:table]) -> window:table
      - creates a new term window object
      - x, y, width and height define the position and size of the window
        - negative values indicate a position relative to the lower right part of the screen
          - x = -10 -> Window begins 10 characters from the right border of the screen.
          - height = -2 -> Window extends to the second last line of the screen.
        - default: 1, 1, -1, -1
      - gpu == nil -> always use primary gpu
    - term.setWindow(window:table) -> oldWindow:table
      - sets the window used by the current process
      - e.g. term.read is now redirected to this object
    - term.getWindow() -> window:table
    - The following functions are available in both the library and in the window object. ("win:func()" vs. "term.func()")
      - setArea(x:number, y:number, width:number, height:number) -> oldX:number, oldY:number, oldWidth:number, oldHeight:number
      - getArea() -> x:number, y:number, width:number, height:number
      - setGPU([gpu:table]) -> oldGPU:table
      - getGPU() -> gpuBeingSet:table, gpuBeingUsed:table
        - gpuBeingUsed = gpuBeingSet or component.gpu
      - getGlobalArea() -> x:number, y:number, width:number, height:number
      - toGlobal(x:number, y:number) -> x:number, y:number
        - transforms window coordinates to screen coordinates
      - toLocal(x:number, y:number) -> x:number, y:number
        - transforms screen coordinates to window coordinates
      - focus()
        - changes the focus to this window
        - Focus changes are only applied after the next "term_focus" signal which is queued after a change.
      - unfocus()
        - removes the focus on this window and changes it to the next known one
        - Focus changes are only applied after the next "term_focus" signal which is queued after a change.
      - focusNext()
        - changes the focus to the next window.
        - Focus changes are only applied after the next "term_focus" signal which is queued after a change.
      - focusPrevious()
        - changes the focus to the previous window
        - Focus changes are only applied after the next "term_focus" signal which is queued after a change.
      - hasFocus() -> isInFocus:boolean, screenAddress:string, keyboardAddress:string
        - returns true if this window is in focus
        - additionally returns the screen and window addresses that are used for event processing
