### PR TITLE
[1.6] Fixed network card message target for servers

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/NetworkCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/NetworkCard.scala
@@ -5,6 +5,7 @@ import li.cil.oc.Settings
 import li.cil.oc.api
 import li.cil.oc.api.Network
 import li.cil.oc.api.component.RackBusConnectable
+import li.cil.oc.api.internal.Rack
 import li.cil.oc.api.machine.Arguments
 import li.cil.oc.api.machine.Callback
 import li.cil.oc.api.machine.Context
@@ -98,13 +99,15 @@ class NetworkCard(val host: EnvironmentHost) extends prefab.ManagedEnvironment w
     result(oldMessage.orNull, oldFuzzy)
   }
 
-  protected def doSend(packet: Packet) {
-    node.sendToReachable("network.message", packet)
-  }
+  protected def doSend(packet: Packet) = host match {
+      case _: Rack => node.sendToNeighbors("network.message", packet)
+      case _ => node.sendToReachable("network.message", packet)
+    }
 
-  protected def doBroadcast(packet: Packet) {
-    node.sendToReachable("network.message", packet)
-  }
+  protected def doBroadcast(packet: Packet) = host match {
+      case _: Rack => node.sendToNeighbors("network.message", packet)
+      case _ => node.sendToReachable("network.message", packet)
+    }
 
   // ----------------------------------------------------------------------- //
 


### PR DESCRIPTION
Passing messages to main node of server by all installed network cards is confusing, can cause duplicate packets as well as multiple hard to fix issues with routing stacks, so I guess messages should be only sent to card's node, as connecting card node to the same(or other ofc) rail main node is connected to is [way] more intuitive than getting duplicate packets.
