### PR TITLE
fix cp one file system option

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/cp.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/cp.lua
@@ -66,17 +66,17 @@ local function recurse(fromPath, toPath, origin)
       io.write("omitting directory `" .. fromPath .. "'\n")
       return true
     end
-    if fs.canonical(fs.path(toPath)):find(fs.canonical(fromPath),1,true)  then
-      return nil, "cannot copy a directory, `" .. fromPath .. "', into itself, `" .. toPath .. "'"
-    end
     if fs.exists(toPath) and not fs.isDirectory(toPath) then
       -- my real cp always does this, even with -f, -n or -i.
       return nil, "cannot overwrite non-directory `" .. toPath .. "' with directory `" .. fromPath .. "'"
     end
-    fs.makeDirectory(toPath)
     if options.x and origin and fs.get(fromPath) ~= origin then
       return true
     end
+    if fs.get(fromPath) == fs.get(toPath) and fs.canonical(fs.path(toPath)):find(fs.canonical(fromPath),1,true)  then
+      return nil, "cannot copy a directory, `" .. fromPath .. "', into itself, `" .. toPath .. "'"
+    end
+    fs.makeDirectory(toPath)
     for file in fs.list(fromPath) do
       local result, reason = recurse(fs.concat(fromPath, file), fs.concat(toPath, file), origin or fs.get(fromPath))
       if not result then


### PR DESCRIPTION
I believe I have the correct intent of cp -x now
I do need to protect from inf. recursive copy, but I added a check to allow parent to child paths when the filesystems are different and -x is specified.

one file system check allows recursive copy where the path is the parent of the destination but said paths are on different file systems

Please review and consider if this is the intended fix for payonel#2
