### PR TITLE
fixing cp -x

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/cp.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/cp.lua
@@ -59,6 +59,11 @@ local function areEqual(path1, path2)
   return result
 end
 
+local mounts = {}
+for dev,path in fs.mounts() do
+  mounts[fs.canonical(path)] = dev
+end
+
 local function recurse(fromPath, toPath, origin)
   status(fromPath, toPath)
   if fs.isDirectory(fromPath) then
@@ -70,7 +75,7 @@ local function recurse(fromPath, toPath, origin)
       -- my real cp always does this, even with -f, -n or -i.
       return nil, "cannot overwrite non-directory `" .. toPath .. "' with directory `" .. fromPath .. "'"
     end
-    if options.x and origin and fs.get(fromPath) ~= origin then
+    if options.x and origin and mounts[fs.canonical(fromPath)] then
       return true
     end
     if fs.get(fromPath) == fs.get(toPath) and fs.canonical(fs.path(toPath)):find(fs.canonical(fromPath),1,true)  then

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/install.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/install.lua
@@ -60,7 +60,7 @@ io.write("Installing " .. name .." to device " .. (choice.getLabel() or choice.a
 os.sleep(0.25)
 local cpPath = filesystem.concat(findMount(filesystem.get(os.getenv("_")).address), "bin/cp")
 local cpOptions = "-vrx" .. (options.u and "ui " or "")
-local cpSource = filesystem.concat(findMount(fromAddress), options.fromDir or "/", "*")
+local cpSource = filesystem.concat(findMount(fromAddress), options.fromDir or "/")
 local cpDest = findMount(choice.address) .. "/"
 local result, reason = os.execute(cpPath .. " " .. cpOptions .. " " .. cpSource .. " " .. cpDest)
 if not result then


### PR DESCRIPTION
Hi Sanger!

So, I have figured out the cp fix I initially was trying to introduce and the correct cp behavior that existed before my first change
1. bring back the work you did in https://github.com/MightyPirates/OpenComputers/commit/e028924d612d73a4c127d1ddc9b4db9e65da6783 - whoops - which is to check if the directory is a mount point
2. but respect the given source path and copy it even if it is a mount point (in the source, I call this "origin", origin is the given source path (the fromPath) in the copy argument)

In other words, -x should not traverse other mount points, but if your path argument points directly to a mount point - that's fine, traverse it.

(2) is a good change, it is linux like: create directories of paths given, even if path given is a mount point [but don't traverse it] BUT through testing I found this is incompatible with install: `cp -rvx /* /mnt/###` because copying /\* INCLUDES /tmp in the copy, which is wrong as tmp is a mount point we don't want during install.

At this point I felt it was best to change the install command to support this change.

so...this means to me that install is slightly wrong, ergo a small change to install (remove the *): `cp -rvx / /mnt/###`
