### PR TITLE
fix term ctrl key (regression), fix grep display

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/93_term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/93_term.lua
@@ -27,3 +27,10 @@ event.listen("component_unavailable", function(_,type)
     end
   end
 end)
+
+event.listen("screen_resized", function(_,addr,w,h)
+  local window = term.internal.window()
+  if term.isAvailable(window) and window.screen.address == addr and window.fullscreen then
+    window.w,window.h = w,h
+  end
+end)

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/process.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/process.lua
@@ -86,10 +86,10 @@ function process.load(path, env, init, name)
       -- msg can be a custom error object
       local msg = result[2]
       if type(msg) == 'table' then
-        assert(msg.reason=="terminated",msg.reason)
+        if msg.reason~="terminated" then error(msg.reason,2) end
         result={0,msg.code}
       else
-        assert(false, msg)
+        error(msg,2)
       end
     end
     return select(2,table.unpack(result))

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -202,12 +202,13 @@ function term.readKeyboard(ops)
   end
   while true do
     local name, address, char, code = term.internal.pull(input)
-    local c, ctrl = nil, kb.isControlDown(address)
+    local c = nil
     hints.cache=char==9 and hints.cache or nil
     if name =="interrupted" then draw("^C\n",true) return ""
     elseif name=="touch" or name=="drag" then term.internal.onTouch(input,char,code)
     elseif name=="clipboard" then c=char
     elseif name=="key_down" then
+      local ctrl = kb.isControlDown(address)
       if ctrl and code == keys.d then return
       elseif char==9 then term.internal.tab(input,hints)
       elseif char==13 and filter(input) then


### PR DESCRIPTION
1. fix filename display in recursive grep results, it is now correctly showing the relative path, no longer the absolute path
2. fix highlighting multiple grep results in a single line
3. fix showing grep results for --match-only where there are multiple matches per line
4. fix crash when using control+key in term.read() This was a regression caused by a recent update to support ctrl+movement for word jumping
