### PR TITLE
make coroutine wrap create tracked coroutines, needed for process data

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/pipes.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/pipes.lua
@@ -137,6 +137,7 @@ function plib.internal.create(fp)
     args = {},
     next = nil,
     create = _co.create,
+    wrap = _co.wrap,
     previous_handler = _co
   }, {__index=_co})
 
@@ -250,15 +251,6 @@ function plib.internal.create(fp)
     end
 
     return _co.status(thread)
-  end
-  function pco.wrap(f)
-    local thread = coroutine.create(f)
-    return function(...)
-      local result_pack = table.pack(pco.resume(thread, ...))
-      local result, reason = result_pack[1], result_pack[2]
-      assert(result, reason)
-      return select(2, table.unpack(result_pack))
-    end
   end
 
   if fp then


### PR DESCRIPTION
Due to our custom handling of process data and coroutines it is necessary to intercept all coroutine creation. Apparently, coroutine.wrap DOES NOT CALL coroutine.create (though it may in pure [C], it doesn't call back to coroutine.create in the user level). This means we need to also wrap wrap ourselves.

This problem is not a regression with OpenOS 1.6, but has existed for ever (since process data was a thing). ServerFS is an addon to OpenOS which creates a virtual fs over the network, and uses coroutine.wrap -- and fails rather quickly in OpenOS 1.6 due to this.
