### PR TITLE
Made memory calculation a lot less hardcoded, finally allowing addons to define custom memory types.

### DIFF
--- a/src/main/java/li/cil/oc/api/driver/item/Memory.java
+++ b/src/main/java/li/cil/oc/api/driver/item/Memory.java
@@ -17,7 +17,8 @@ public interface Memory extends Item {
      * This factor has to be interpreted by each individual architecture to fit
      * its own memory needs. The actual values returned here should roughly be
      * equivalent to the item's tier. For example, the built-in memory modules
-     * provide 1 for tier one, 2 for tier 1.5, 3 for tier 2, etc.
+     * provide defaults of 192 for tier one, 256 for tier 1.5, 384 for tier 2, etc.
+     * Mind that those values may be changed in the config file.
      *
      * @param stack the item to get the provided memory for.
      * @return the amount of memory the specified component provides.

--- a/src/main/scala/li/cil/oc/integration/opencomputers/DriverMemory.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/DriverMemory.scala
@@ -12,7 +12,9 @@ import net.minecraft.item.ItemStack
 object DriverMemory extends Item with api.driver.item.Memory with api.driver.item.CallBudget {
   override def amount(stack: ItemStack) =
     Delegator.subItem(stack) match {
-      case Some(memory: item.Memory) => memory.tier + 1
+      case Some(memory: item.Memory) =>
+        val sizes = Settings.get.ramSizes
+        Settings.get.ramSizes(memory.tier max 0 min (sizes.length - 1))
       case _ => 0.0
     }
 

--- a/src/main/scala/li/cil/oc/server/machine/luac/NativeLuaArchitecture.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luac/NativeLuaArchitecture.scala
@@ -157,13 +157,10 @@ abstract class NativeLuaArchitecture(val machine: api.machine.Machine) extends A
     memory > 0
   }
 
-  private def memoryInBytes(components: java.lang.Iterable[ItemStack]) = components.foldLeft(0)((acc, stack) => acc + (Option(api.Driver.driverFor(stack)) match {
-    case Some(driver: Memory) =>
-      val sizes = Settings.get.ramSizes
-      val tier = math.round(driver.amount(stack)).toInt - 1
-      sizes(tier max 0 min (sizes.length - 1)) * 1024
+  private def memoryInBytes(components: java.lang.Iterable[ItemStack]) = components.foldLeft(0.0)((acc, stack) => acc + (Option(api.Driver.driverFor(stack)) match {
+    case Some(driver: Memory) => driver.amount(stack) * 1024
     case _ => 0
-  }))
+  })).toInt max 0 min 50000000
 
   // ----------------------------------------------------------------------- //
 

--- a/src/main/scala/li/cil/oc/server/machine/luaj/LuaJLuaArchitecture.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luaj/LuaJLuaArchitecture.scala
@@ -102,13 +102,10 @@ class LuaJLuaArchitecture(val machine: api.machine.Machine) extends Architecture
     memory > 0
   }
 
-  private def memoryInBytes(components: java.lang.Iterable[ItemStack]) = components.foldLeft(0)((acc, stack) => acc + (Option(api.Driver.driverFor(stack)) match {
-    case Some(driver: Memory) =>
-      val sizes = Settings.get.ramSizes
-      val tier = math.round(driver.amount(stack)).toInt - 1
-      sizes(tier max 0 min (sizes.length - 1)) * 1024
+  private def memoryInBytes(components: java.lang.Iterable[ItemStack]) = components.foldLeft(0.0)((acc, stack) => acc + (Option(api.Driver.driverFor(stack)) match {
+    case Some(driver: Memory) => driver.amount(stack) * 1024
     case _ => 0
-  }))
+  })).toInt max 0 min 50000000
 
   // ----------------------------------------------------------------------- //
 


### PR DESCRIPTION
This is an important change for addons adding custom architectures as it changes the default values of OC Memory. It allows for addons to add their own types of memory in the Lua architecture. No longer is it hardcoded to the six values specified in the config file as those are used by the Memory instance itself now instead of the architecture, also making other architectures benefit from the config option. Furthermore, the memory calculated has been clamped between 0 and 50 MB (still a lot) to avoid integer overflows in case the config settings are too high.
