### PR TITLE
delay load, term, and grep fixed

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/grep.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/grep.lua
@@ -279,11 +279,11 @@ local function test(m,p)
       write(':', COLON_COLOR)
       needs_line_num = nil
     end
-    local p=m_only and '' or m.line:sub(last_index,(i or 0)-1)
+    local s=m_only and '' or m.line:sub(last_index,(i or 0)-1)
     local g=i and m.line:sub(i,j) or ''
-    if i==1 then g=trim_front(g) elseif last_index==1 then p=trim_front(p) end
-    if j==slen then g=trim_back(g) elseif not i then p=trim_back(p) end
-    write(p)
+    if i==1 then g=trim_front(g) elseif last_index==1 then s=trim_front(s) end
+    if j==slen then g=trim_back(g) elseif not i then s=trim_back(s) end
+    write(s)
     write(g, MATCH_COLOR)
     empty_line = false
     last_index = (j or slen)+1
@@ -291,7 +291,7 @@ local function test(m,p)
       write("\n")
       empty_line = true
       needs_filename, needs_line_num = include_filename, print_line_num
-    end
+    elseif p:find("^^") then break end
   end
   if not empty_line then write("\n") end
 end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/sh.lua
@@ -30,6 +30,7 @@ if #args == 0 and (io.stdin.tty or options.i) and not options.c then
       local foreground = gpu.setForeground(0xFF0000)
       term.write(sh.expand(os.getenv("PS1") or "$ "))
       gpu.setForeground(foreground)
+      term.setCursorBlink(true)
       local command = term.read(history, nil, sh.hintHandler)
       if not command then
         io.write("exit\n")

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/tools/delayLookup.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/tools/delayLookup.lua
@@ -1,0 +1,33 @@
+local data,tbl,key = ...
+local z = data[tbl]
+
+if key then -- index
+  local method = z.methods[key]
+  local cache = z.cache[key]
+  if method and not cache then
+    local file = io.open(z.path,"r")
+    if file then
+      file:seek("set", method[1])
+      local loaded = load("return function"..file:read(method[2]), "=delayed-"..key,"t",z.env)
+      file:close()
+      assert(loaded,"failed to load "..key)
+      cache = loaded()
+      --lazy_protect(key, cache)
+      z.cache[key] = cache
+    end
+  end
+  return cache
+else -- pairs
+  local set,k,v = {}
+  while true do
+    k,v = next(tbl,k)
+    if not k then break end
+    set[k] = v
+  end
+  for k in pairs(z.methods) do
+    if not set[k] then
+      set[k] = function(...)return tbl[k](...)end
+    end
+  end
+  return pairs(set)
+end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/tools/delayParse.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/tools/delayParse.lua
@@ -1,4 +1,4 @@
-local filepath,delay_index,delay_newindex,delay_pairs = ...
+local filepath,delay_data = ...
 local file, reason = io.open(filepath, "r")
 if not file then
   return reason
@@ -45,23 +45,20 @@ local library, local_env = loader()
 if library then
   local_env = local_env or {}
   local_env[lib_name] = library
-  local mt =
-  {
-    methods={},
-    cache={},
-    env=setmetatable(local_env, {__index=_G}),
-    path=filepath,
-    __pairs=delay_pairs,
-    __index=delay_index,
-    __newindex=delay_newindex,
-  }
+
+  local env = setmetatable(local_env, {__index=_G})
   
   for path,pack in pairs(methods) do
     local target = library
     for name in path:gmatch("[^%.]+") do target = target[name] end
-    mt.methods[target]=pack
-    mt.cache[target]={}
-    setmetatable(target, mt)
+    delay_data[target] =
+    {
+      methods = pack,
+      cache = {},
+      env = env,
+      path = filepath
+    }
+    setmetatable(target, delay_data)
   end
 
   return function()return library end, filepath


### PR DESCRIPTION
Delayload is lighter weight now. Improving method reuse and reducing boot costs about about 1.5k

term had some crashes and improper behavior. This fixed tab complete for 5.3 lua archs, term palette use, and missing tab complete hints. Term blinking now also supports setCursorBlink(false).

grep had a bug where patterns looking for start-of-line text would find in-line matches as well.
