### PR TITLE
term wrapping and sh tab completion fixes

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
@@ -69,7 +69,7 @@ if #args == 0 or options.i then
   local function findKeys(t, r, prefix, name)
     if type(t) ~= "table" then return end
     for k, v in pairs(t) do
-      if string.match(k, "^"..name) then
+      if type(k) == "string" and string.match(k, "^"..name) then
         local postfix = ""
         if type(v) == "function" then postfix = "()"
         elseif type(v) == "table" and getmetatable(v) and getmetatable(v).__call then postfix = "()"

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/sh.lua
@@ -482,7 +482,7 @@ function --[[@delayloaded-start@]] sh.getMatchingPrograms(baseName)
     baseName = "^(" .. text.escapeMagic(baseName) .. ".*)%.lua$"
   end
   for basePath in string.gmatch(os.getenv("PATH"), "[^:]+") do
-    for file in fs.list(basePath) do
+    for file in fs.list(shell.resolve(basePath)) do
       local match = file:match(baseName)
       if match and not result_keys[match] then
         table.insert(result, match)

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -231,14 +231,15 @@ function term.readKeyboard(ops)
   while true do
     local name, address, char, code = term.internal.pull(input)
     local c = nil
-    hints.cache=char==9 and hints.cache or nil
+    local backup_cache = hints.cache
     if name =="interrupted" then draw("^C\n",true) return ""
     elseif name=="touch" or name=="drag" then term.internal.onTouch(input,char,code)
-    elseif name=="clipboard" then c=char
+    elseif name=="clipboard" then c=char hints.cache = nil
     elseif name=="key_down" then
+      hints.cache = nil
       local ctrl = kb.isControlDown(address)
       if ctrl and code == keys.d then return
-      elseif char==9 then term.internal.tab(input,hints)
+      elseif char==9 then hints.cache = backup_cache term.internal.tab(input,hints)
       elseif char==13 and filter(input) then
         input:move(math.huge)
         if db ~= false then draw("\n") end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -105,7 +105,8 @@ end
 function term.read(history,dobreak,hintHandler,pwchar,filter)
   if not io.stdin.tty then return io.read() end
   local ops = history or {}
-  ops.dobreak = ops.dobreak or dobreak
+  ops.dobreak = ops.dobreak
+  if ops.dobreak==nil then ops.dobreak = dobreak end
   ops.hintHandler = ops.hintHandler or hintHandler
   ops.pwchar = ops.pwchar or pwchar
   ops.filter = ops.filter or filter
@@ -397,6 +398,8 @@ end --[[@delayloaded-end@]]
 
 function --[[@delayloaded-start@]] term.internal.onTouch(input,gx,gy)
   input:move(math.huge)
+  local w = W()
+  gx,gy=gx-w.dx,gy-w.dy
   local x2,y2,d = input.w.x,input.w.y,input.w.w
   input:move((gy*d+gx)-(y2*d+x2))
 end --[[@delayloaded-end@]]
@@ -474,8 +477,8 @@ end --[[@delayloaded-end@]]
 
 function --[[@delayloaded-start@]] term.internal.filter(filter,input)
   if not filter then return true
-  elseif type(filter) == "string" then return input:match(filter)
-  elseif filter(input) then return true
+  elseif type(filter) == "string" then return input.data:match(filter)
+  elseif filter(input.data) then return true
   else require("computer").beep(2000, 0.1) end
 end --[[@delayloaded-end@]]
 


### PR DESCRIPTION
term wrapping fixes
Backspacing or deleting during vertical wrap would not update the current end of line correctly what the text was being pulled from the next line

horizontal wrapping deletion was not using dx,dy and instead was removing text from absolute positions on the screen

horizontal wrapping was pushing spaces beyond the windowed areas
