### PR TITLE
Continue tab complete on single hit results into children

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
@@ -98,6 +98,22 @@ if #args == 0 or options.i then
       table.insert(r2, k)
     end
     table.sort(r2)
+    if #r2 == 1 then
+      setmetatable(r2, {
+        __index=function(tbl, key)
+          if key==2 then
+            local prev=tbl[1]
+            tbl[1]=nil
+            local next = hint(prev,#prev+1)
+            for i,v in ipairs(next) do
+              tbl[i] = v
+            end
+            setmetatable(tbl,getmetatable(next))
+            return tbl[1]
+          end
+        end,
+        __len=function()return 2 end})
+    end
     return r2
   end
 


### PR DESCRIPTION
This is not high priority, and not super heavily tested. Just for your consideration. If you do like this idea, allow me to give it more testing first. Also, this will merge conflict with https://github.com/MightyPirates/OpenComputers/pull/1737 - so if you do like this idea, I'll update this PR anyways.

Tab complete in the lua prompt shows . on tables, but can give the wrong impression that there are no keys. Consider that the user types =filesyste[tab] and then sees =filesystem. and presses tab again. The hint table has only one entry, "=filesystem." and is cycling through that one entry and not reconsidering children of filesystem .. which is what the prompt makes the user think. This change injects a metamethod lookup in the 2nd index of a single result to repop the hint list with new children.
