### PR TITLE
Shift tab

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -263,6 +263,8 @@ function term.readKeyboard(ops)
         input:update(0)
       elseif char>=32 then
         c=unicode.char(char)
+      else
+        hints.cache = backup_cache
       end
     end
     if c then input:update(c) end
@@ -491,7 +493,8 @@ function --[[@delayloaded-start@]] term.internal.tab(input,hints)
     hints.cache.i=-1
   end
   local c=hints.cache
-  c.i=(c.i+1)%math.max(#c,1)
+  local change = kb.isShiftDown(term.keyboard().address) and -1 or 1
+  c.i=(c.i+change)%math.max(#c,1)
   local next=c[c.i+1]
   if next then
     local tail = unicode.wlen(input.data) - input.index - 1


### PR DESCRIPTION
Added (brought back) support to check shift keypress on tab key use to cycle hints in reverse. Tested no result sets, single result sets, and multiple result sets. Tested at start, mid, and at end of sets. Retested recent bug where we would lose the hint cache.
