### PR TITLE
big awesome update for devfs, command substitution, and io redirection

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/03_io.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/03_io.lua
@@ -33,14 +33,19 @@ function stdoutStream:write(str)
 end
 
 function stderrStream:write(str)
-  local component = require("component")
-  if component.isAvailable("gpu") and component.gpu.getDepth() and component.gpu.getDepth() > 1 then
-    local foreground = component.gpu.setForeground(0xFF0000)
-    term.write(str, true)
-    component.gpu.setForeground(foreground)
-  else
-    term.write(str, true)
+  local gpu = term.gpu()
+  local set_depth = gpu and gpu.getDepth() and gpu.getDepth() > 1
+
+  if set_depth then
+    set_depth = gpu.setForeground(0xFF0000)
   end
+    
+  term.drawText(str, true)
+
+  if set_depth then
+    gpu.setForeground(set_depth)
+  end
+
   return self
 end
 

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/10_devfs.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/10_devfs.lua
@@ -1,0 +1,7 @@
+require("filesystem").mount(
+setmetatable({
+  isReadOnly = function()return true end
+},
+{
+  __index=function(tbl,key)return require("devfs")[key]end
+}), "/dev")

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/devfs.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/devfs.lua
@@ -1,0 +1,87 @@
+local fs = require("filesystem")
+
+local proxy = {points={},address=require("guid").next()}
+
+local nop = function()end
+
+function proxy.getLabel()
+  return "devfs"
+end
+
+function proxy.list()
+  local keys = {}
+  for k,v in pairs(proxy.points) do
+    table.insert(keys, k)
+  end
+  return keys
+end
+
+function proxy.exists(path)
+  return not not proxy.points[path]
+end
+
+function proxy.remove(path)
+  if not proxy.exists(path) then return false end
+  proxy.points[path] = nil
+  return true
+end
+
+function proxy.isDirectory(path)
+  return false
+end
+
+function proxy.size(path)
+  return 0
+end
+
+function proxy.lastModified(path)
+  return fs.lastModified("/dev/")
+end
+
+function proxy.read(h,...)
+  return h:read(...)
+end
+
+function proxy.write(h,...)
+  return h:write(...)
+end
+
+proxy.close = nop
+
+function proxy.open(path, mode)
+  checkArg(1, path, "string")
+
+  local handle = proxy.points[path]
+  if not handle then return nil, "device point [" .. path .. "] does not exist" end
+
+  local msg = "device point [" .. path .. "] cannot be opened for "
+
+  if mode == "r" then
+    if not handle.read then
+      return nil, msg .. "read"
+    end
+  else
+    if not handle.write then
+      return nil, msg .. "write"
+    end
+  end
+
+  return handle
+end
+
+function proxy.create(path, handle)
+  handle.close = handle.close or nop
+  proxy.points[path] = handle
+  return true
+end
+
+proxy.create("null", {write = nop})
+proxy.create("random", {read = function(_,n)
+  local chars = {}
+  for i=1,n do
+    table.insert(chars,string.char(math.random(0,255)))
+  end
+  return table.concat(chars)
+end})
+
+return proxy

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/shell.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/shell.lua
@@ -35,7 +35,7 @@ local function findFile(name, ext)
     dir = fs.concat(fs.concat(dir, name), "..")
     local name = fs.name(name)
     local list = fs.list(dir)
-    if list then
+    if list and name then
       local files = {}
       for file in list do
         files[file] = true


### PR DESCRIPTION
[Edit: for clarification, tests are in a different repo]

This change should be fully compatible with any 1.6 user scripts. This makes no change to api, only improves shell support and makes important process handle cleanup (when pipes and redirection are used - we are not auto-closing user file handles).

This update also reduces RAM costs by another 1300 bytes.

This PR focuses on 3 major feature and various bug fixes found along the way.
## devfs
- devfs mounts a virtual device at /dev. With this release I am only adding /dev/null and /dev/random. The lib/devfs provides a create method to allow user defined dev points.
## stderr
- stderr (io[2]) is now entirely its own io stream, separate from stdout (io[1]). Along with providing a true stderr separation it was necessary to support numbered stdio redirection: #>&# (e.g. >&2 or 2>&1, or even 2>/dev/null)
## command substitution
- Support for command substitution is provide via backticks `. Backtick text is resolved as a sub process and the stdout (io[1]) of the process replaces the text inline. set list=`ls` would set $list to the string of the output of ls
