### PR TITLE
devfs should be rw

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/boot/10_devfs.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/boot/10_devfs.lua
@@ -1,6 +1,6 @@
 require("filesystem").mount(
 setmetatable({
-  isReadOnly = function()return true end
+  isReadOnly = function()return false end
 },
 {
   __index=function(tbl,key)return require("devfs")[key]end

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/devfs.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/devfs.lua
@@ -12,10 +12,6 @@ function proxy.setLabel(value)
   error("drive does not support labeling")
 end
 
-function proxy.isReadOnly()
-  return false
-end
-
 function proxy.spaceTotal()
   return 0
 end


### PR DESCRIPTION
This should be returned in the boot devfs file, not the lib devfs. We already have a method defined in boot/10_devfs, just moving the logic to return false and removing it from /lib/devfs
