### PR TITLE
simplify term hint text indexing and fix lua prompt hint handler

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/bin/lua.lua
@@ -85,7 +85,9 @@ if #args == 0 or options.i then
     end
   end
   local function hint(line, index)
-    line = (line or ""):sub(1, index - 1)
+    line = (line or "")
+    local tail = line:sub(index)
+    line = line:sub(1, index - 1)
     local path = string.match(line, "[a-zA-Z_][a-zA-Z0-9_.]*$")
     if not path then return nil end
     local suffix = string.match(path, "[^.]+$") or ""
@@ -95,7 +97,7 @@ if #args == 0 or options.i then
     local r1, r2 = {}, {}
     findKeys(t, r1, string.sub(line, 1, #line - #suffix), suffix)
     for k in pairs(r1) do
-      table.insert(r2, k)
+      table.insert(r2, k .. tail)
     end
     table.sort(r2)
     if #r2 == 1 then
@@ -103,10 +105,11 @@ if #args == 0 or options.i then
         __index=function(tbl, key)
           if key==2 then
             local prev=tbl[1]
-            tbl[1]=nil
             local next = hint(prev,#prev+1)
-            for i,v in ipairs(next) do
-              tbl[i] = v
+            if next then
+              for i,v in ipairs(next) do
+                tbl[i] = v
+              end
             end
             setmetatable(tbl,getmetatable(next))
             return tbl[1]

--- a/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/OpenOS/lib/term.lua
@@ -517,7 +517,7 @@ function --[[@delayloaded-start@]] term.internal.tab(input,hints)
   c.i=(c.i+change)%math.max(#c,1)
   local next=c[c.i+1]
   if next then
-    local tail = unicode.wlen(input.data) - input.index - 1
+    local tail = unicode.len(input.data) - input.index
     input:clear()
     input:update(next)
     input:move(-tail)


### PR DESCRIPTION
This PR fixes 3 issues
1. #1813 
2. shell prompt tab complete would "walk" the cursor one position on each tab hit
3. lua prompt tab complete would remove trailing text
### fix for #1813

Regression from https://github.com/payonel/OpenComputers/commit/db332dbf385055bf72332d14a7d7ba7b3c21c505 -- silly mistake where a tab complete of a function name in lua prompt would not have children and thus the lua hint would return nil. This PR adds a safety net around possible nil returns.
### shell prompt tab complete walking

This is a regression fix from before the major term overhaul. The issue is based on the callback "index" of the text having a one-off error.

repro: (cursor position indicated by | )

shell> ca| foo.txt
// press [tab]
shell> cat |foo.txt
// press [tab]
shell> cache f|oo.txt
// press [tab]
shell> cat fo|o.txt

The issue being that the cursor would step forward by one position on each tab complete. This fix also improves the lua.lua prompt related to the following 3rd item.
### lua prompt tab complete cuts trailing text

@gamax92 pointed out the following: ( | indicates cursor position)

lua> abc=123
// enter (to create abc variable for test)
lua> ab|=33
// tab
lua> |abc

The previous item fixed in this PR also fixes the cursor positioning issue here, but additionally this PR has a fix for the trailing text. The solution is simply to append the trailing text to the lua prompt hint results. 

Note that the lua prompt hint handler is not as advanced as the shell prompt -- thus this change would cause a strange edge case:

lua> abc=123
lua> ab|d
// tab
lua> abc|d

If this is an acceptable side effect, this PR is ready as is.
