### PR TITLE
plan9k .prop to guide openos install

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/plan9k/.prop
+++ b/src/main/resources/assets/opencomputers/loot/plan9k/.prop
@@ -1,0 +1,1 @@
+{label="Plan9k",reboot=true,setlabel=true,setboot=true}


### PR DESCRIPTION
I debated with myself about some of these properties for plan9k

plan9k has its own installer, but magik6k and i agree it would be better to have a .prop file in case a use is running install with openos, but also has a plan9k loot disk in the computer.

The main reason to add this .prop is to label the target drive. But the options I'm not sure about are setboot and reboot

setboot: sets the computer's boot address  to the target drive. If the user is installing plan9k on a separate drive, they could be doing so for another machine, in which case we don't want the current machine's boot address to change. But also they could be installing it to a new drive to try out on the current machine, in which case we DO want this option. My thinking is that because 1. it is an os, and 2. openos behaves this way, that the user might expect setboot to be the case for this loot disk as well. As with ALL values from .prop, the user gets priority via command line. In this case, the user could call `install --nosetboot`

reboot: This one doesn't matter as much as setboot. Setting the boot address happens whether or not the user chooses to reboot (unlike legacy install). So, reboot doesn't need to happen after install, but if the user is changing the boot address, it typically makes sense to reboot. So, if setboot is true, it makes sense in most cases to also reboot
