### PR TITLE
changes to pwd and /mnt

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/boot/90_filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/90_filesystem.lua
@@ -22,7 +22,7 @@ local function onInit()
 end
 
 local function onComponentAdded(_, address, componentType)
-  if componentType == "filesystem" then
+  if componentType == "filesystem" and require("computer").tmpAddress() ~= address then
     local proxy = component.proxy(address)
     if proxy then
       local name = address:sub(1, 3)

--- a/src/main/resources/assets/opencomputers/loot/openos/etc/profile
+++ b/src/main/resources/assets/opencomputers/loot/openos/etc/profile
@@ -17,7 +17,7 @@ set HOME=/home
 set IFS=\ 
 set MANPATH=/usr/man:.
 set PAGER=/bin/more
-set PS1='$PWD# '
+set PS1='$PWD # '
 set PWD=/
 set SHELL=/bin/sh
 set LS_COLORS="{FILE=0xFFFFFF,DIR=0x66CCFF,LINK=0xFFAA00,['*.lua']=0x00FF00}"

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/shell.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/shell.lua
@@ -127,13 +127,15 @@ function shell.resolveAlias(command, args)
 end
 
 function shell.getWorkingDirectory()
+  -- if no env PWD default to /
   return os.getenv("PWD") or "/"
 end
 
 function shell.setWorkingDirectory(dir)
   checkArg(1, dir, "string")
-  dir = fs.canonical(dir) .. "/"
-  if dir == "//" then dir = "/" end
+  -- ensure at least /
+  -- and remove trailing /
+  dir = fs.canonical(dir):gsub("^$", "/"):gsub("(.)/$", "%1")
   if fs.isDirectory(dir) then
     os.setenv("PWD", dir)
     return true


### PR DESCRIPTION
Functional and objective fixes moved to #1903

filesystem: don't mount tmpfs in /mnt
~~buffer: don't allow reading zero bytes from a stream, and fix libraries that should be allowed to set zero size buffer~~
~~install: report setting boot address, ^d should not accept prompts~~
~~ls: use shell to get working dir, not PWD~~
~~package: remove clutter for library keys and _G~~
~~profile: PS1 to use : instead of #~~
~~rc: add unload to lib methods and fix typo in source~~
~~sh: remove clutter from _G and use zero sized buffer for piping~~
shell: remove trailing slash for pwd
