### PR TITLE
fixes for buffer, install, ls, package, profile, rc, sh

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/install.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/install.lua
@@ -31,13 +31,16 @@ if options.setlabel then
 end
 
 if options.setboot then
-  computer.setBootAddress(options.target.dev.address)
+  local address = options.target.dev.address
+  if computer.setBootAddress(address) then
+    write("Boot address set to " .. address)
+  end
 end
 
 if options.reboot then
   write("Reboot now? [Y/n] ")
-  local result = read()
-  if not result or result == "" or result:sub(1, 1):lower() == "y" then
+  local result = read() or "n"
+  if result:sub(1, 1):lower() == "y" then
     write("\nRebooting now!\n")
     computer.shutdown(true)
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/ls.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/ls.lua
@@ -284,7 +284,7 @@ local function displayDirList(dirs)
     end
   end
 end
-local tr,cp={},{path=os.getenv("PWD")}
+local tr,cp={},{path=shell.getWorkingDirectory()}
 for _,dir in ipairs(dirsArg) do
   local path = shell.resolve(dir)
   if not fs.exists(path) then

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/rc.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/rc.lua
@@ -44,7 +44,7 @@ local function load(name, args)
   return nil, reason
 end
 
-function unload(name)
+function rc.unload(name)
   rc.loaded[name] = nil
 end
 
@@ -60,15 +60,15 @@ local function rawRunCommand(conf, name, cmd, args, ...)
       end
       return true
     elseif type(result[cmd]) == "function" then
-      res, what = xpcall(result[cmd], debug.traceback, ...)
-      if res then
+      result, what = xpcall(result[cmd], debug.traceback, ...)
+      if result then
         return true
       end
     elseif cmd == "restart" and type(result["stop"]) == "function" and type(result["start"]) == "function" then
-      res, what = xpcall(result["stop"], debug.traceback, ...)
-      if res then
-        res, what = xpcall(result["start"], debug.traceback, ...)
-        if res then
+      result, what = xpcall(result["stop"], debug.traceback, ...)
+      if result then
+        result, what = xpcall(result["start"], debug.traceback, ...)
+        if result then
           return true
         end
       end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/buffer.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/buffer.lua
@@ -73,7 +73,7 @@ function buffer:read(...)
     if computer.uptime() > timeout then
       error("timeout")
     end
-    local result, reason = self.stream:read(self.bufferSize)
+    local result, reason = self.stream:read(math.max(1,self.bufferSize))
     if result then
       self.bufferRead = self.bufferRead .. result
       return self

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/package.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/package.lua
@@ -61,15 +61,13 @@ end
 local delay_data = {}
 local delay_tools = setmetatable({},{__mode="v"})
 
-package.delay_data = delay_data
-
 function delay_data.__index(tbl,key)
   delay_data.lookup = delay_data.lookup or loadfile("/lib/tools/delayLookup.lua")
   return delay_data.lookup(delay_data, tbl, key)
 end
 delay_data.__pairs = delay_data.__index -- nil key acts like pairs
 
-function delaySearcher(module)
+local function delaySearcher(module)
   if not delayed[module] then
     return "\tno field package.delayed['" .. module .. "']"
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/pipes.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/pipes.lua
@@ -367,7 +367,7 @@ function plib.popen(prog, mode, env)
   pm.pco=plib.internal.create(pm.root)
   
   local pfd = require("buffer").new(mode, pipeStream.new(pm))
-  pfd:setvbuf("no", nil) -- 2nd are to read chunk size
+  pfd:setvbuf("no", 0) -- 2nd are to read chunk size
 
   -- popen processes start on create (which is LAME :P)
   pfd.stream:resume()

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/sh.lua
@@ -12,8 +12,8 @@ sh.internal = {}
 
 -- --[[@@]] are not just comments, but custom annotations for delayload methods.
 -- See package.lua and the api wiki for more information
-function isWordOf(w, vs) return w and #w == 1 and not w[1].qr and tx.first(vs,{{w[1].txt}}) ~= nil end
-function isWord(w,v) return isWordOf(w,{v}) end
+local function isWordOf(w, vs) return w and #w == 1 and not w[1].qr and tx.first(vs,{{w[1].txt}}) ~= nil end
+local function isWord(w,v) return isWordOf(w,{v}) end
 local local_env = {event=event,fs=fs,process=process,shell=shell,term=term,text=text,tx=tx,unicode=unicode,isWordOf=isWordOf,isWord=isWord}
 
 -------------------------------------------------------------------------------
@@ -424,7 +424,7 @@ function --[[@delayloaded-start@]] sh.internal.buildPipeChain(threads)
     local pipe
     if i < #threads then
       pipe = require("buffer").new("rw", sh.internal.newMemoryStream())
-      pipe:setvbuf("no")
+      pipe:setvbuf("no", 0)
       -- buffer close flushes the buffer, but we have no buffer
       -- also, when the buffer is closed, read and writes don't pass through
       -- simply put, we don't want buffer:close
@@ -461,7 +461,7 @@ function --[[@delayloaded-start@]] sh.internal.glob(glob_pattern)
   end
 
   local is_abs = glob_pattern:sub(1, 1) == "/"
-  local root = is_abs and '' or shell.getWorkingDirectory()
+  local root = is_abs and '' or shell.getWorkingDirectory():gsub("([^/])$","%1/")
   local paths = {is_abs and "/" or ''}
   local relative_separator = ''
 


### PR DESCRIPTION
This is a prerequisite for #1900

buffer: don't allow reading zero bytes from a stream, and fix libraries that should be allowed to set zero size buffer
install: report setting boot address, ^d should not accept prompts
ls: use shell to get working dir, not PWD
package: remove clutter for library keys and _G
rc: add unload to lib methods and fix typo in source
sh: remove clutter from _G and use zero sized buffer for piping
