### PR TITLE
fixes for install, cp, ln, and shell parsing

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/cp.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/cp.lua
@@ -67,9 +67,10 @@ local function recurse(fromPath, toPath, origin)
   local isLink, target = fs.isLink(fromPath)
   local toIsLink, toLinkTarget = fs.isLink(toPath)
   local same_path = fs.canonical(isLink and target or fromPath) == fs.canonical(toIsLink and toLinkTarget or toPath)
+  local same_link = isLink and toIsLink and same_path
   local toExists = fs.exists(toPath)
-
-  if isLink and options.P and (not toExists or not same_path) then
+  
+  if isLink and options.P and not (toExists and same_path and not toIsLink) then
     if toExists and options.n then
       return true
     end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/install.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/install.lua
@@ -23,7 +23,6 @@ if ec ~= nil and ec ~= 0 then
 end
 
 local write = io.write
-local read = io.read
 write("Installation complete!\n")
 
 if options.setlabel then
@@ -39,8 +38,7 @@ end
 
 if options.reboot then
   write("Reboot now? [Y/n] ")
-  local result = read() or "n"
-  if result:sub(1, 1):lower() == "y" then
+  if ((io.read() or "n").."y"):match("^%s*[Yy]") then
     write("\nRebooting now!\n")
     computer.shutdown(true)
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/ln.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/ln.lua
@@ -9,6 +9,13 @@ if #dirs == 0 then
 end
 
 local target = shell.resolve(dirs[1])
+
+-- don't link from target if it doesn't exist, unless it is a broken link
+if not fs.exists(target) and not fs.isLink(target) then
+  io.stderr:write("ln: failed to access '" .. target .. "': No such file or directory\n")
+  return 1
+end
+
 local linkpath
 if #dirs > 1 then
   linkpath = shell.resolve(dirs[2])

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/tools/install_basics.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/tools/install_basics.lua
@@ -7,7 +7,6 @@ local unicode = require("unicode")
 local text = require("text")
 
 local write = io.write
-local read = io.read
 
 local args, options = shell.parse(...)
 
@@ -174,7 +173,7 @@ options.source_dir = fs.canonical(source.prop.fromDir or options.fromDir or "") 
 
 local installer_path = options.source_root .. "/.install"
 if fs.exists(installer_path) then
-  return loadfile("/lib/tools/install_utils.lua", "bt", _G)('install', options)
+  os.exit(loadfile("/lib/tools/install_utils.lua", "bt", _G)('install', options))
 end
 
 local cp_args =
@@ -190,8 +189,7 @@ if #options.targets > 1 or options.to then
   special_target = " to " .. cp_args[3]
 end
 io.write("Install " .. source_display .. special_target .. "? [Y/n] ")
-local choice = read():lower()
-if choice ~= "y" and choice ~= "" then
+if not ((io.read() or "n").."y"):match("^%s*[Yy]") then
   write("Installation cancelled\n")
   os.exit()
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/tools/install_utils.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/tools/install_utils.lua
@@ -22,8 +22,8 @@ local function select_prompt(devs, prompt)
     io.write("Enter 'q' to cancel the installation: ")
     choice = nil
     while not choice do
-      result = io.read()
-      if result:sub(1, 1):lower() == "q" then
+      result = io.read() or "q"
+      if result == "q" then
         os.exit()
       end
       local number = tonumber(result)


### PR DESCRIPTION
fix install stdin read defaults
fix cp over links to update links
fixed ''| parse error (it isn't)
better os.exit for customer installer
