### PR TITLE
a possible too-many-screens' solution

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/boot/04_component.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/04_component.lua
@@ -101,6 +101,7 @@ function component.setPrimary(componentType, address)
     if wasAvailable or wasAdding then
       adding[componentType] = {
         address=address,
+        proxy = primary,
         timer=event.timer(0.1, function()
           adding[componentType] = nil
           primaries[componentType] = primary
@@ -116,14 +117,55 @@ end
 
 -------------------------------------------------------------------------------
 
-for address in component.list('screen', true) do
-  if #component.invoke(address,'getKeyboards') > 0 then
-    component.setPrimary('screen',address)
-  end
-end
-
 local function onComponentAdded(_, address, componentType)
-  if not (primaries[componentType] or adding[componentType]) then
+  local prev = primaries[componentType] or (adding[componentType] and adding[componentType].proxy)
+
+  if prev then
+    -- special handlers -- some components are just better at being primary
+    if componentType == "screen" then
+      --the primary has no keyboards but we do
+      if #prev.getKeyboards() == 0 then
+        local first_kb = component.invoke(address, 'getKeyboards')[1]
+        if first_kb then
+          -- just in case our kb failed to achieve primary
+          -- possible if existing primary keyboard became primary first without a screen
+          -- then prev (a screen) was added without a keyboard
+          -- and then we attached this screen+kb pair, and our kb fired first - failing to achieve primary
+          -- also, our kb may fire right after this, which is fine
+          component.setPrimary("keyboard", first_kb)
+          prev = nil -- nil meaning we should take this new one over the previous
+        end
+      end
+    elseif componentType == "keyboard" then
+      -- to reduce signal noise, if this kb is also the prev, we do not need to reset primary
+      if address ~= prev.address then
+        --keyboards never replace primary keyboards unless the are the only keyboard on the primary screen
+        local current_screen = primaries.screen or (adding.screen and adding.screen.proxy)
+        --if there is not yet a screen, do not use this keyboard, it's not any better
+        if current_screen then
+          -- the next phase is complicated
+          -- there is already a screen and there is already a keyboard
+          -- this keyboard is only better if this is a keyboard of the primary screen AND the current keyboard is not
+          -- i don't think we can trust kb order (1st vs 2nd), 2nd could fire first
+          -- but if there are two kbs on a screen, we can give preferred treatment to the first
+          -- thus, assume 2nd is not attached for the purposes of primary kb
+          -- and THUS, whichever (if either) is the 1st kb of the current screen
+          -- this is only possible if
+          -- 1. the only kb on the system (current) has no screen
+          -- 2. a screen is added without a kb
+          -- 3. this kb is added later manually
+
+          -- prev is true when addr is not equal to the primary keyboard of the current screen -- meaning
+          -- when addr is different, and thus it is not the primary keyboard, then we ignore this
+          -- keyboard, and keep the previous
+          -- prev is false means we should take this new keyboard
+          prev = address ~= current_screen.getKeyboards()[1]
+        end
+      end
+    end
+  end
+
+  if not prev then
     component.setPrimary(componentType, address)
   end
 end
@@ -138,3 +180,8 @@ end
 
 event.listen("component_added", onComponentAdded)
 event.listen("component_removed", onComponentRemoved)
+
+if component.boot_screen then
+  component.setPrimary("screen", component.boot_screen)
+  component.boot_screen = nil
+end

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/93_term.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/93_term.lua
@@ -15,7 +15,7 @@ event.listen("gpu_bound", function(ename, gpu, screen)
 end)
 
 event.listen("component_unavailable", function(_,type)
-  if type == "screen" or type == "gpu" then
+  if type == "screen" or type == "gpu" or type == "keyboard" then
     if term.isAvailable() then
       local window = term.internal.window()
       if window[type] and not component.proxy(window[type].address) then
@@ -24,6 +24,21 @@ event.listen("component_unavailable", function(_,type)
     end
     if not term.isAvailable() then
       computer.pushSignal("term_unavailable")
+    end
+  end
+end)
+
+event.listen("component_available", function(_,type)
+  -- we need to clear the current terminals cached keyboard (if any) when a new keyboard becomes available
+  -- this is in case the new keyboard was attached to the terminal's window
+  -- the terminal library has the code to determine what the best keyboard to use is
+  -- but here, we'll just set the cache to nil to force term library to reload it
+  -- an alternative to this method would be to make sure the terminal library doesn't cache the wrong keybaord to begin with
+  -- but, users may actually expect that any primary keyboard is a valid keyboard (weird, in my opinion)
+  if type == "keyboard" then
+    local window = term.internal.window()
+    if window then
+      window.keyboard = nil
     end
   end
 end)

--- a/src/main/resources/assets/opencomputers/loot/openos/init.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/init.lua
@@ -32,8 +32,11 @@ do
   for address in component.list('screen', true) do
     if #component.invoke(address, 'getKeyboards') > 0 then
       screen = address
+      break
     end
   end
+
+  component.boot_screen = screen
 
   -- Report boot progress if possible.
   local gpu = component.list("gpu", true)()
@@ -150,16 +153,8 @@ do
 
   status("Initializing components...")
 
-  local primaries = {}
   for c, t in component.list() do
-    local s = component.slot(c)
-    if not primaries[t] or (s >= 0 and s < primaries[t].slot) then
-      primaries[t] = {address=c, slot=s}
-    end
     computer.pushSignal("component_added", c, t)
-  end
-  for t, c in pairs(primaries) do
-    component.setPrimary(t, c.address)
   end
   os.sleep(0.5) -- Allow signal processing by libraries.
   computer.pushSignal("init") -- so libs know components are initialized.


### PR DESCRIPTION
**Recommended for post 1.6 release**
This PR might be best for post 1.6 release because it is rewriting some rather critical boot level operations (although, completely backwards compatible). In my testing I have found this stable and accurate, but this PR fixes a low priority issue with some risky level code.

This fixes #1933

init: remove primary component intialization from init, and give full component control to component driver (it already had the primary component code, init was trying to accomplish the same logic)

04_component: add screen and keyboard "upgrading" to the component.setPrimary code path. There are cases where a keyboard or a screen should become the new primary component, and other cases where they should be ignored. This logic is based on permutations where a user boot with screens and keyboards and adds/removes screens and keyboards after boot. Keyboard may and may not be attached to screens in all permutations. The experience should be predictable for the user, and always the primary screen should match the primary keyboard as a pair when the primary screen has a keyboard

04_component: add logic to reuse the boot screen as the first primary screen option

term library: cache the screen-attached keyboard and check keyboard events against it
term library: remove cached keyboards from the terminal on component_removed -- this forces the terminal to recache the keyboard
term library: assume keyboard unknown on start - this allows keyboard removals and additions to not interfere with terminal operations
