### PR TITLE
The too-many-screens' solution

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -430,7 +430,7 @@ local function find()
     setStatus("Find: " .. findText)
 
     local _, address, char, code = term.pull("key_down")
-    if address == term.keyboard().address then
+    if address == term.keyboard() then
       local handler, name = getKeyBindHandler(code)
       highlight(cbx, cby, unicode.wlen(findText), false)
       if name == "newline" then
@@ -557,7 +557,7 @@ getKeyBindHandler = function(code)
             elseif value == "shift" then shift = true
             else key = value end
           end
-          local keyboardAddress = term.keyboard().address
+          local keyboardAddress = term.keyboard()
           if (not alt or keyboard.isAltDown(keyboardAddress)) and
              (not control or keyboard.isControlDown(keyboardAddress)) and
              (not shift or keyboard.isShiftDown(keyboardAddress)) and
@@ -656,7 +656,7 @@ end
 
 while running do
   local event, address, arg1, arg2, arg3 = term.pull()
-  if address == term.keyboard().address or address == term.screen().address then
+  if address == term.keyboard() or address == term.screen() then
     local blink = true
     if event == "key_down" then
       onKeyDown(arg1, arg2)

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/04_component.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/04_component.lua
@@ -101,6 +101,7 @@ function component.setPrimary(componentType, address)
     if wasAvailable or wasAdding then
       adding[componentType] = {
         address=address,
+        proxy = primary,
         timer=event.timer(0.1, function()
           adding[componentType] = nil
           primaries[componentType] = primary
@@ -116,14 +117,55 @@ end
 
 -------------------------------------------------------------------------------
 
-for address in component.list('screen', true) do
-  if #component.invoke(address,'getKeyboards') > 0 then
-    component.setPrimary('screen',address)
-  end
-end
-
 local function onComponentAdded(_, address, componentType)
-  if not (primaries[componentType] or adding[componentType]) then
+  local prev = primaries[componentType] or (adding[componentType] and adding[componentType].proxy)
+
+  if prev then
+    -- special handlers -- some components are just better at being primary
+    if componentType == "screen" then
+      --the primary has no keyboards but we do
+      if #prev.getKeyboards() == 0 then
+        local first_kb = component.invoke(address, 'getKeyboards')[1]
+        if first_kb then
+          -- just in case our kb failed to achieve primary
+          -- possible if existing primary keyboard became primary first without a screen
+          -- then prev (a screen) was added without a keyboard
+          -- and then we attached this screen+kb pair, and our kb fired first - failing to achieve primary
+          -- also, our kb may fire right after this, which is fine
+          component.setPrimary("keyboard", first_kb)
+          prev = nil -- nil meaning we should take this new one over the previous
+        end
+      end
+    elseif componentType == "keyboard" then
+      -- to reduce signal noise, if this kb is also the prev, we do not need to reset primary
+      if address ~= prev.address then
+        --keyboards never replace primary keyboards unless the are the only keyboard on the primary screen
+        local current_screen = primaries.screen or (adding.screen and adding.screen.proxy)
+        --if there is not yet a screen, do not use this keyboard, it's not any better
+        if current_screen then
+          -- the next phase is complicated
+          -- there is already a screen and there is already a keyboard
+          -- this keyboard is only better if this is a keyboard of the primary screen AND the current keyboard is not
+          -- i don't think we can trust kb order (1st vs 2nd), 2nd could fire first
+          -- but if there are two kbs on a screen, we can give preferred treatment to the first
+          -- thus, assume 2nd is not attached for the purposes of primary kb
+          -- and THUS, whichever (if either) is the 1st kb of the current screen
+          -- this is only possible if
+          -- 1. the only kb on the system (current) has no screen
+          -- 2. a screen is added without a kb
+          -- 3. this kb is added later manually
+
+          -- prev is true when addr is not equal to the primary keyboard of the current screen -- meaning
+          -- when addr is different, and thus it is not the primary keyboard, then we ignore this
+          -- keyboard, and keep the previous
+          -- prev is false means we should take this new keyboard
+          prev = address ~= current_screen.getKeyboards()[1]
+        end
+      end
+    end
+  end
+
+  if not prev then
     component.setPrimary(componentType, address)
   end
 end
@@ -132,9 +174,31 @@ local function onComponentRemoved(_, address, componentType)
   if primaries[componentType] and primaries[componentType].address == address or
      adding[componentType] and adding[componentType].address == address
   then
-    component.setPrimary(componentType, component.list(componentType, true)())
+    local next = component.list(componentType, true)()
+    component.setPrimary(componentType, next)
+
+    if componentType == "screen" and next then
+      -- setPrimary already set the proxy (if successful)
+      local proxy = (primaries.screen or (adding.screen and adding.screen.proxy))
+      if proxy then
+        -- if a screen is removed, and the primary keyboard is actually attached to another, non-primary, screen
+        -- then the `next` screen, if it has a keyboard, should TAKE priority
+        local next_kb = proxy.getKeyboards()[1] -- costly, don't call this method often
+        local old_kb = primaries.keyboard or adding.keyboard
+        -- if the next screen doesn't have a kb, this operation is without purpose, leave things as they are
+        -- if there was no previous kb, use the new one
+        if next_kb and (not old_kb or old_kb.address ~= next_kb) then
+          component.setPrimary("keyboard", next_kb)
+        end
+      end
+    end
   end
 end
 
 event.listen("component_added", onComponentAdded)
 event.listen("component_removed", onComponentRemoved)
+
+if _G.boot_screen then
+  component.setPrimary("screen", _G.boot_screen)
+end
+_G.boot_screen = nil

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/93_term.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/93_term.lua
@@ -7,30 +7,59 @@ local process = require("process")
 -- this should be the init level process
 process.info().data.window = term.internal.open()
 
-event.listen("gpu_bound", function(ename, gpu, screen)
+event.listen("gpu_bound", function(ename, gpu)
   gpu=component.proxy(gpu)
-  screen=component.proxy(screen)
-  term.bind(gpu, screen)
+  term.bind(gpu)
   computer.pushSignal("term_available")
 end)
 
-event.listen("component_unavailable", function(_,type)
-  if type == "screen" or type == "gpu" then
-    if term.isAvailable() then
-      local window = term.internal.window()
-      if window[type] and not component.proxy(window[type].address) then
-        window[type] = nil
-      end
-    end
-    if not term.isAvailable() then
-      computer.pushSignal("term_unavailable")
-    end
+local function components_changed(ename, address, type)
+  local window = term.internal.window()
+  if not window then
+    return
   end
-end)
+
+  if ename == "component_available" or ename == "component_unavailable" then
+    type = address
+  end
+
+  if ename == "component_removed" or ename == "component_unavailable" then
+     -- address can be type, when ename is *_unavailable, but *_removed works here and that's all we need
+    if type == "gpu" and window.gpu.address == address then
+      window.gpu = nil
+      window.keyboard = nil
+    elseif type == "keyboard" then
+      -- we could check if this was our keyboard
+      -- i.e. if address == window.keyboard
+      -- but it is also simple for the terminal to
+      -- recheck what kb to use
+      window.keyboard = nil
+    end
+  elseif (ename == "component_added" or ename == "component_available") and type == "keyboard" then
+  -- we need to clear the current terminals cached keyboard (if any) when
+  -- a new keyboard becomes available. This is in case the new keyboard was
+  -- attached to the terminal's window. The terminal library has the code to
+  -- determine what the best keyboard to use is, but here we'll just set the
+  -- cache to nil to force term library to reload it. An alternative to this
+  -- method would be to make sure the terminal library doesn't cache the
+  -- wrong keybaord to begin with but, users may actually expect that any
+  -- primary keyboard is a valid keyboard (weird, in my opinion)
+    window.keyboard = nil
+  end
+
+  if (type == "screen" or type == "gpu") and not term.isAvailable() then
+    computer.pushSignal("term_unavailable")
+  end
+end
+
+event.listen("component_removed",     components_changed)
+event.listen("component_added",       components_changed)
+event.listen("component_available",   components_changed)
+event.listen("component_unavailable", components_changed)
 
 event.listen("screen_resized", function(_,addr,w,h)
   local window = term.internal.window()
-  if term.isAvailable(window) and window.screen.address == addr and window.fullscreen then
+  if term.isAvailable(window) and term.screen(window) == addr and window.fullscreen then
     window.w,window.h = w,h
   end
 end)

--- a/src/main/resources/assets/opencomputers/loot/openos/init.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/init.lua
@@ -32,8 +32,11 @@ do
   for address in component.list('screen', true) do
     if #component.invoke(address, 'getKeyboards') > 0 then
       screen = address
+      break
     end
   end
+
+  _G.boot_screen = screen
 
   -- Report boot progress if possible.
   local gpu = component.list("gpu", true)()
@@ -150,16 +153,8 @@ do
 
   status("Initializing components...")
 
-  local primaries = {}
   for c, t in component.list() do
-    local s = component.slot(c)
-    if not primaries[t] or (s >= 0 and s < primaries[t].slot) then
-      primaries[t] = {address=c, slot=s}
-    end
     computer.pushSignal("component_added", c, t)
-  end
-  for t, c in pairs(primaries) do
-    component.setPrimary(t, c.address)
   end
   os.sleep(0.5) -- Allow signal processing by libraries.
   computer.pushSignal("init") -- so libs know components are initialized.

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/keyboard.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/keyboard.lua
@@ -42,14 +42,7 @@ setmetatable(keyboard.keys,
 -------------------------------------------------------------------------------
 
 local function getKeyboardAddress(address)
-  if address then
-    return address
-  else
-    local primary = component.isAvailable("keyboard") and component.getPrimary("keyboard")
-    if primary then
-      return primary.address
-    end
-  end
+  return address or require("term").keyboard()
 end
 
 local function getPressedCodes(address)


### PR DESCRIPTION
boot screen is preserved
screen with keyboard always gets keyboard focus
lost screens automatically switch to available screens
screens without keyboards that are primary screens correctly take keyboard focus if given a keyboard
and closes #1933 
