### PR TITLE
Fix internet TCP events

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/InternetCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/InternetCard.scala
@@ -185,7 +185,7 @@ object InternetCard {
   }
 
   object TCPNotifier extends Thread {
-    private val selector = Selector.open()
+    private var selector = Selector.open()
     private val toAccept = new ConcurrentLinkedQueue[(SocketChannel, () => Unit)]
 
     override def run(): Unit = {
@@ -200,10 +200,20 @@ object InternetCard {
 
           import scala.collection.JavaConversions._
           val selectedKeys = selector.selectedKeys
+          val readableKeys = mutable.HashSet[SelectionKey]()
           selectedKeys.filter(_.isReadable).foreach(key => {
-            key.cancel()
-            key.attachment().asInstanceOf[() => Unit].apply()
+            key.attachment.asInstanceOf[() => Unit].apply()
+            readableKeys += key
           })
+
+          if(readableKeys.nonEmpty) {
+            val newSelector = Selector.open()
+            selectedKeys.filter(!readableKeys.contains(_)).foreach(key => {
+              key.channel.register(newSelector, SelectionKey.OP_READ, key.attachment)
+            })
+            selector.close()
+            selector = newSelector
+          }
         } catch {
           case e: IOException =>
             OpenComputers.log.error("Error in TCP selector loop.", e)


### PR DESCRIPTION
It's impossible to add channel SelectionKey back to selector if it was cancelled. The only workaround to his seems to be creating new selector each time. Other way this could be done would be to remove op_read from keys' interest ops, but that broke java select implementation on Linux. This seems to be the only way to get this kind of behavior. With usual usage of TCP in OC it shouldn't use much CPU.
