### PR TITLE
act like closed pipe when terminal becomes unavailable

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
@@ -239,7 +239,9 @@ function term.readKeyboard(ops)
 
   while true do
     local name, address, char, code = term.internal.pull(input)
-    assert(term.isAvailable(), "term_unavailable")
+    if not term.isAvailable() then
+      return
+    end
 
     -- we have to keep checking what kb is active in case it is switching during use
     -- we could have multiple screens, each with keyboards active


### PR DESCRIPTION
it should be a soft check for terminal availability, while it can be logical for an assert from the perspective of the shell -- which can handle all types of terminal closures -- it would make more sense for an application (which is not necessarily as robust as the shell) to have the perspective that the terminal is closed (unavailable) rather than crashing (aborting) simply because the screen is lost. It's not an exception, just a loss of a connection.
