### PR TITLE
Change scheduleIC2Add to use IEnergySink instead of IEnergyTile

### DIFF
--- a/src/main/scala/li/cil/oc/common/EventHandler.scala
+++ b/src/main/scala/li/cil/oc/common/EventHandler.scala
@@ -113,7 +113,7 @@ object EventHandler {
   def scheduleIC2Add(tileEntity: power.IndustrialCraft2Experimental) {
     if (SideTracker.isServer) pendingServer.synchronized {
       pendingServer += (() => if (!tileEntity.addedToIC2PowerGrid && !tileEntity.isInvalid) {
-        MinecraftForge.EVENT_BUS.post(new ic2.api.energy.event.EnergyTileLoadEvent(tileEntity.asInstanceOf[ic2.api.energy.tile.IEnergyTile]))
+        MinecraftForge.EVENT_BUS.post(new ic2.api.energy.event.EnergyTileLoadEvent(tileEntity.asInstanceOf[ic2.api.energy.tile.IEnergySink]))
         tileEntity.addedToIC2PowerGrid = true
       })
     }


### PR DESCRIPTION
Fixes #1937.
Tested and confirmed working with IC2-exp v2.6.15 as well as EnderIO v3.0.1.73 for 1.10.2.
