### PR TITLE
Added SignChangeEvent to sign upgrade

### DIFF
--- a/src/main/java/li/cil/oc/api/event/SignChangeEvent.java
+++ b/src/main/java/li/cil/oc/api/event/SignChangeEvent.java
@@ -1,0 +1,31 @@
+package li.cil.oc.api.event;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.tileentity.TileEntitySign;
+
+/**
+ * A bit more specific sign change event that holds information about new text of the sign. Used in the sign upgrade.
+ */
+public abstract class SignChangeEvent extends Event {
+    public final TileEntitySign sign;
+    public final String[] lines;
+
+    private SignChangeEvent(TileEntitySign sign, String[] lines) {
+        this.sign = sign;
+        this.lines = lines;
+    }
+
+    @Cancelable
+    public static class Pre extends SignChangeEvent {
+        public Pre(TileEntitySign sign, String[] lines) {
+            super(sign, lines);
+        }
+    }
+
+    public static class Post extends SignChangeEvent {
+        public Post(TileEntitySign sign, String[] lines) {
+            super(sign, lines);
+        }
+    }
+}

--- a/src/main/scala/li/cil/oc/server/component/UpgradeSign.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeSign.scala
@@ -9,6 +9,7 @@ import li.cil.oc.api.driver.DeviceInfo.DeviceClass
 import li.cil.oc.Settings
 import li.cil.oc.api
 import li.cil.oc.api.driver.DeviceInfo
+import li.cil.oc.api.event.SignChangeEvent
 import li.cil.oc.api.network.EnvironmentHost
 import li.cil.oc.api.internal
 import li.cil.oc.api.network.Message
@@ -53,12 +54,18 @@ abstract class UpgradeSign extends prefab.ManagedEnvironment with DeviceInfo {
           case robot: internal.Robot => robot.player
           case _ => FakePlayerFactory.get(host.world.asInstanceOf[WorldServer], Settings.get.fakePlayerProfile)
         }
-        if (!canChangeSign(player, sign)) {
+
+        val lines = text.lines.padTo(4, "").map(line => if (line.length > 15) line.substring(0, 15) else line).toArray
+
+        if (!canChangeSign(player, sign, lines)) {
           return result(Unit, "not allowed")
         }
 
-        text.lines.padTo(4, "").map(line => if (line.length > 15) line.substring(0, 15) else line).copyToArray(sign.signText)
+        lines.copyToArray(sign.signText)
         host.world.markBlockForUpdate(sign.xCoord, sign.yCoord, sign.zCoord)
+
+        MinecraftForge.EVENT_BUS.post(new SignChangeEvent.Post(sign, lines))
+
         result(sign.signText.mkString("\n"))
       case _ => result(Unit, "no sign")
     }
@@ -75,13 +82,20 @@ abstract class UpgradeSign extends prefab.ManagedEnvironment with DeviceInfo {
     }
   }
 
-  private def canChangeSign(player: EntityPlayer, tileEntity: TileEntitySign): Boolean = {
+  private def canChangeSign(player: EntityPlayer, tileEntity: TileEntitySign, lines: Array[String]): Boolean = {
     if (!host.world.canMineBlock(player, tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord)) {
       return false
     }
+
     val event = new BlockEvent.BreakEvent(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, host.world, tileEntity.getBlockType, tileEntity.getBlockMetadata, player)
     MinecraftForge.EVENT_BUS.post(event)
-    !(event.isCanceled || event.getResult == Event.Result.DENY)
+    if (event.isCanceled || event.getResult == Event.Result.DENY) {
+      return false
+    }
+
+    val signEvent = new SignChangeEvent.Pre(tileEntity, lines)
+    MinecraftForge.EVENT_BUS.post(signEvent)
+    !(signEvent.isCanceled || signEvent.getResult == Event.Result.DENY)
   }
 
   override def onMessage(message: Message): Unit = {


### PR DESCRIPTION
It would be useful for server (especially Bukkit, but maybe some others too) where plugins treat specific signs in a special manner (e.g. shops or warps). Without this event it's hard to prevent robots from creating these signs, this event introduces an explicit capability to do so.
