### PR TITLE
Fix bit32.lrotate and bit32.rrotate

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/bit32.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/bit32.lua
@@ -66,9 +66,15 @@ function bit32.replace(n, v, field, width)
 end
 
 function bit32.lrotate(x, disp)
-  if disp == 0 then return x
-  elseif disp < 0 then return bit32.rrotate(x, -disp)
-  else return trim((x << disp) | (x >> (32 - disp))) end
+  if disp == 0 then
+    return x
+  elseif disp < 0 then
+    return bit32.rrotate(x, -disp)
+  else
+    disp = disp & 31
+    x = trim(x)
+    return trim((x << disp) | (x >> (32 - disp)))
+  end
 end
 
 function bit32.lshift(x, disp)
@@ -76,9 +82,15 @@ function bit32.lshift(x, disp)
 end
 
 function bit32.rrotate(x, disp)
-  if disp == 0 then return x
-  elseif disp < 0 then return bit32.lrotate(x, -disp)
-  else return trim((x >> disp) | (x << (32 - disp))) end
+  if disp == 0 then
+    return x
+  elseif disp < 0 then
+    return bit32.lrotate(x, -disp)
+  else
+    disp = disp & 31
+    x = trim(x)
+    return trim((x >> disp) | (x << (32 - disp)))
+  end
 end
 
 function bit32.rshift(x, disp)


### PR DESCRIPTION
### Bug

If any of two arguments is too big, those functions return 0 instead of an expected value.
### Steps to reproduce
1. Switch processor architecure to Lua 5.3.
2. Run the following code: `require("bit32").lrotate(11111111111111111, 2222222222222)`.

It returns 0. Expected return value: 3340540761.
### Fix

Trim the `x` argument, and use at most 5 bits of `disp` (`disp & (LUA_NBITS - 1)`, where `LUA_NBITS = 32`).

---

Implementation of those functions in Lua 5.2: [https://www.lua.org/source/5.2/lbitlib.c.html#b_rot](https://www.lua.org/source/5.2/lbitlib.c.html#b_rot).
