### PR TITLE
Check if the world is remote before killing the drone

### DIFF
--- a/src/main/scala/li/cil/oc/common/entity/Drone.scala
+++ b/src/main/scala/li/cil/oc/common/entity/Drone.scala
@@ -467,7 +467,9 @@ class Drone(val world: World) extends Entity(world) with MachineHost with intern
   override def interactFirst(player: EntityPlayer) = {
     if (player.isSneaking) {
       if (Wrench.isWrench(player.getHeldItem)) {
-        kill()
+        if(!world.isRemote) {
+          kill()
+        }
       }
       else if (!world.isRemote && !machine.isRunning) {
         preparePowerUp()


### PR DESCRIPTION
Drones were getting invisible when a player attempts to drop it (wrench + sneak + right click) and a server mod cancels the interaction.
