### PR TITLE
World Inventory Analytics Improvements

### DIFF
--- a/src/main/java/li/cil/oc/api/prefab/ItemStackArrayValue.java
+++ b/src/main/java/li/cil/oc/api/prefab/ItemStackArrayValue.java
@@ -1,0 +1,136 @@
+package li.cil.oc.api.prefab;
+
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+
+import java.util.HashMap;
+import java.util.TreeMap;
+
+public class ItemStackArrayValue extends AbstractValue {
+
+	private ItemStack[] array = null;
+	private int iteratorIndex;
+
+	private static final byte TAGLIST_ID = (new NBTTagList()).getId();
+	private static final byte COMPOUND_ID = (new NBTTagCompound()).getId();
+	private static final String ARRAY_KEY = "Array";
+	private static final String INDEX_KEY = "Index";
+
+	private static final HashMap<Object,Object> emptyMap = new HashMap<Object,Object>();
+
+	public ItemStackArrayValue(ItemStack[] arr){
+		if (arr != null){
+			this.array = new ItemStack[arr.length];
+			for (int i=0; i< arr.length; i++){
+				this.array[i] = arr[i] != null ? arr[i].copy() : null;
+			}
+		}
+		this.iteratorIndex = 0;
+	}
+
+	public ItemStackArrayValue(){
+		this(null);
+	}
+
+	@Override
+	public Object[] call(Context context, Arguments arguments) {
+		if (this.array == null)
+			return null;
+		if (this.iteratorIndex >= this.array.length)
+			return null;
+		int index = this.iteratorIndex++;
+		if (this.array[index] == null)//TODO 1.11 change to ItemStack.EMPTY?
+			return new Object[]{ emptyMap };
+		return new Object[]{ this.array[index] != null ? this.array[index] : emptyMap };
+	}
+
+	@Override
+	public Object apply(Context context, Arguments arguments) {
+		if (arguments.count() == 0 || this.array == null)
+			return null;
+		if (arguments.isInteger(0)){//index access
+			int luaIndex = arguments.checkInteger(0);
+			if (luaIndex > this.array.length || luaIndex < 1){
+				return null;
+			}
+			return this.array[luaIndex-1];
+		}
+		if (arguments.isString(0)){
+			String arg = arguments.checkString(0);
+			if (arg.equals("n")){
+				return this.array.length;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void load(NBTTagCompound nbt) {
+		if (nbt.hasKey(ARRAY_KEY, TAGLIST_ID)){
+			NBTTagList tagList = nbt.getTagList(ARRAY_KEY,COMPOUND_ID);
+			this.array = new ItemStack[tagList.tagCount()];
+			for (int i = 0; i < tagList.tagCount(); ++i){
+				NBTTagCompound el = tagList.getCompoundTagAt(i);
+				if (el.hasNoTags())
+					this.array[i] = null;//TODO 1.11 change to ItemStack.EMPTY?
+				else
+					this.array[i] = ItemStack.loadItemStackFromNBT(el);
+			}
+		} else {
+			this.array = null;
+		}
+		this.iteratorIndex = nbt.getInteger(INDEX_KEY);
+	}
+
+	@Override
+	public void save(NBTTagCompound nbt) {
+
+		NBTTagCompound nullnbt = new NBTTagCompound();
+
+		if (this.array != null) {
+			NBTTagList nbttaglist = new NBTTagList();
+			for (ItemStack stack : this.array) {
+				if (stack != null) {
+					NBTBase nbttagcompound = stack.serializeNBT();
+					nbttaglist.appendTag(nbttagcompound);
+				} else {
+					nbttaglist.appendTag(nullnbt);
+				}
+			}
+
+			nbt.setTag(ARRAY_KEY, nbttaglist);
+		}
+
+		nbt.setInteger(INDEX_KEY, iteratorIndex);
+	}
+
+	@Callback(doc="function():nil -- Reset the iterator index so that the next call will return the first element.")
+	public Object[] reset(Context context, Arguments arguments) throws Exception {
+		this.iteratorIndex = 0;
+		return null;
+	}
+
+	@Callback(doc="function():number -- Returns the number of elements in the this.array.")
+	public Object[] count(Context context, Arguments arguments) throws Exception {
+		return new Object[] { this.array != null ? this.array.length : 0 };
+	}
+
+	@Callback(doc="function():table -- Returns ALL the stack in the this.array. Memory intensive.")
+	public Object[] getAll(Context context, Arguments arguments) throws Exception {
+		TreeMap<Integer,Object> map = new TreeMap<Integer,Object>();
+		for (int i=0; i<this.array.length; i++){
+			map.put(i, this.array[i] != null ? this.array[i] : emptyMap);
+		}
+		return new Object[] { map };
+	}
+
+	public String toString(){
+		return "{ItemStack Array}";
+	}
+}
+

--- a/src/main/scala/li/cil/oc/server/component/traits/WorldInventoryAnalytics.scala
+++ b/src/main/scala/li/cil/oc/server/component/traits/WorldInventoryAnalytics.scala
@@ -76,6 +76,22 @@ trait WorldInventoryAnalytics extends WorldAware with SideRestricted with Networ
   }
   else result(Unit, "not enabled in config")
 
+  @Callback(doc = """function(side:number):table -- Get a description of all stacks in the inventory on the specified side of the device.""")
+  def getAllStacks(context: Context, args: Arguments): Array[AnyRef] = if (Settings.get.allowItemStackInspection) {
+    val facing = checkSideForAction(args, 0)
+    withInventory(facing, inventory => {
+        var stacks = new Array[AnyRef](inventory.getSizeInventory)
+        for(i <- 0 to inventory.getSizeInventory - 1){
+          stacks(i) = inventory.getStackInSlot(i)
+          if (stacks(i) == null) {
+            stacks(i) = scala.collection.mutable.Map.empty[AnyRef, AnyRef]
+          }
+        }
+        result(stacks)
+      })
+  }
+  else result(Unit, "not enabled in config")
+
   @Callback(doc = """function(side:number, slot:number, dbAddress:string, dbSlot:number):boolean -- Store an item stack description in the specified slot of the database with the specified address.""")
   def store(context: Context, args: Arguments): Array[AnyRef] = {
     val facing = checkSideForAction(args, 0)

--- a/src/main/scala/li/cil/oc/server/component/traits/WorldInventoryAnalytics.scala
+++ b/src/main/scala/li/cil/oc/server/component/traits/WorldInventoryAnalytics.scala
@@ -92,6 +92,12 @@ trait WorldInventoryAnalytics extends WorldAware with SideRestricted with Networ
   }
   else result(Unit, "not enabled in config")
 
+  @Callback(doc = """function(side:number):string -- Get the the name of the inventory on the specified side of the device.""")
+  def getInventoryName(context: Context, args: Arguments): Array[AnyRef] = {
+    val facing = checkSideForAction(args, 0)
+    withInventory(facing, inventory => result(inventory.getName()))
+  }
+
   @Callback(doc = """function(side:number, slot:number, dbAddress:string, dbSlot:number):boolean -- Store an item stack description in the specified slot of the database with the specified address.""")
   def store(context: Context, args: Arguments): Array[AnyRef] = {
     val facing = checkSideForAction(args, 0)

--- a/src/main/scala/li/cil/oc/server/machine/luac/UserdataAPI.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luac/UserdataAPI.scala
@@ -8,6 +8,7 @@ import java.io.DataOutputStream
 import li.cil.oc.OpenComputers
 import li.cil.oc.api.Persistable
 import li.cil.oc.api.machine.Value
+import li.cil.oc.server.driver.Registry
 import li.cil.oc.server.machine.ArgumentsImpl
 import li.cil.oc.util.ExtendedLuaState.extendLuaState
 import net.minecraft.nbt.CompressedStreamTools
@@ -56,7 +57,7 @@ class UserdataAPI(owner: NativeLuaArchitecture) extends NativeLuaAPI(owner) {
     lua.pushScalaFunction(lua => {
       val value = lua.toJavaObjectRaw(1).asInstanceOf[Value]
       val args = lua.toSimpleJavaObjects(2)
-      owner.invoke(() => Array(value.apply(machine, new ArgumentsImpl(args))))
+      owner.invoke(() => Registry.convert(Array(value.apply(machine, new ArgumentsImpl(args)))))
     })
     lua.setField(-2, "apply")
 
@@ -73,7 +74,7 @@ class UserdataAPI(owner: NativeLuaArchitecture) extends NativeLuaAPI(owner) {
     lua.pushScalaFunction(lua => {
       val value = lua.toJavaObjectRaw(1).asInstanceOf[Value]
       val args = lua.toSimpleJavaObjects(2)
-      owner.invoke(() => value.call(machine, new ArgumentsImpl(args)))
+      owner.invoke(() => Registry.convert(value.call(machine, new ArgumentsImpl(args))))
     })
     lua.setField(-2, "call")
 

--- a/src/main/scala/li/cil/oc/server/machine/luaj/UserdataAPI.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luaj/UserdataAPI.scala
@@ -2,6 +2,7 @@ package li.cil.oc.server.machine.luaj
 
 import li.cil.oc.OpenComputers
 import li.cil.oc.api.machine.Value
+import li.cil.oc.server.driver.Registry
 import li.cil.oc.server.machine.ArgumentsImpl
 import li.cil.oc.util.ScalaClosure._
 import li.cil.repack.org.luaj.vm2.LuaValue
@@ -16,7 +17,7 @@ class UserdataAPI(owner: LuaJLuaArchitecture) extends LuaJAPI(owner) {
     userdata.set("apply", (args: Varargs) => {
       val value = args.checkuserdata(1, classOf[Value]).asInstanceOf[Value]
       val params = toSimpleJavaObjects(args, 2)
-      owner.invoke(() => Array(value.apply(machine, new ArgumentsImpl(params))))
+      owner.invoke(() => Registry.convert(Array(value.apply(machine, new ArgumentsImpl(params)))))
     })
 
     userdata.set("unapply", (args: Varargs) => {
@@ -31,7 +32,7 @@ class UserdataAPI(owner: LuaJLuaArchitecture) extends LuaJAPI(owner) {
     userdata.set("call", (args: Varargs) => {
       val value = args.checkuserdata(1, classOf[Value]).asInstanceOf[Value]
       val params = toSimpleJavaObjects(args, 2)
-      owner.invoke(() => value.call(machine, new ArgumentsImpl(params)))
+      owner.invoke(() => Registry.convert(value.call(machine, new ArgumentsImpl(params))))
     })
 
     userdata.set("dispose", (args: Varargs) => {


### PR DESCRIPTION
I have ported getAllStacks & getInventoryName from the vanilla inventory driver so that Inventory Controller Upgrades, Transposers, etc can use those functions.

My Reasoning is in #2065
My function also has a benefit of not fooling Lua with array size, an empty slot with the Vanilla driver seems to stop iterating upon a nil element. My function gives it an empty table (as ItemStacks show as tables in Lua getStackInSlot()).

I did getInventoryName because it also seems useful to know if we're interacting with the correct inventory.
