### PR TITLE
Re-added EnderIO integration and added Bundled Redstone support for EnderIO's Insulated Redstone Conduits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,12 @@ repositories {
     maven {
         name = "IGW"
         url = "http://maven.k-4u.nl/"
-    }/*
+    }
+    maven {
+        name 'EnderIO'
+        url "http://maven.tterrag.com"
+    }
+    /*
     maven {
         name = "dmodoomsirius"
         url = "http://api.dmodoomsirius.me/"
@@ -154,10 +159,6 @@ repositories {
     ivy {
         name 'MineFactoryReloaded'
         artifactPattern "http://addons-origin.cursecdn.com/files/${config.mfr.cf}/[module]-[revision].[ext]"
-    }
-    ivy {
-        name 'EnderIO'
-        artifactPattern "http://addons-origin.cursecdn.com/files/${config.eio.cf}/[module]-[revision].[ext]"
     }
     ivy {
         name 'Railcraft'
@@ -213,8 +214,21 @@ dependencies {
     provided ("mrtjp:ProjectRed:${config.projred.version}:dev") {
         exclude module: 'CoFHCore'
     }
-    provided "coloredlightscore:ColoredLightsCore:${config.coloredlights.version}:api"
-
+    provided "coloredlightscore:ColoredLightsCore:${config.coloredlights.version}:api"*/
+    deobfCompile "com.enderio.core:EnderCore:${config.ec.version}"
+    deobfCompile("com.enderio:EnderIO:${config.eio.version}") {
+        exclude module: "appliedenergistics2"
+        exclude module: "buildcraft"
+        exclude module: "Waila"
+        exclude module: "forestry_1.10.2"
+        exclude module: "OpenComputers"
+        exclude module: "CodeChickenLib"
+        exclude module: "CodeChickenCore"
+        exclude module: "EquivalentExchange3"
+        exclude module: "jei_1.10.2"
+        exclude module: "Tesla"
+    }
+/*
     provided name: 'buildcraft', version: config.bc.version, classifier: "dev", ext: 'jar'
     provided name: 'GalacticraftCoreAll', version: config.gc.version, ext: 'jar'
     provided name: 'MekanismAll', version: config.mekanism.version, ext: 'jar'
@@ -223,7 +237,6 @@ dependencies {
     provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
     provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
     provided name: 'MineFactoryReloaded', version: config.mfr.version, ext: 'jar'
-    provided name: 'EnderIO', version: config.eio.version, ext: 'jar'
     provided name: 'Railcraft', version: config.rc.version, ext: 'jar'
     provided name: 'BloodMagic', version: config.bloodmagic.version, ext: 'jar'
     provided name: 'ExtraCells', version: config.ec.version, ext: 'jar'
@@ -261,7 +274,7 @@ sourceSets {
             exclude 'li/cil/oc/integration/computercraft/**'
             exclude 'li/cil/oc/integration/dsu/**'
             exclude 'li/cil/oc/integration/ec/**'
-            exclude 'li/cil/oc/integration/enderio/**'
+            //exclude 'li/cil/oc/integration/enderio/**'
             //exclude 'li/cil/oc/integration/enderstorage/**'
             exclude 'li/cil/oc/integration/fmp/**'
             exclude 'li/cil/oc/integration/gc/**'

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.10.2
 minecraft.mappings=snapshot_20160720
-forge.version=12.18.1.2014
+forge.version=12.18.2.2122
 
 oc.version=1.6.0
 oc.subversion=dev
@@ -18,10 +18,8 @@ cofhlib.cf=2230/207
 cofhlib.version=[1.7.10]1.0.0RC7-127
 coloredlights.version=1.3.7.35
 coloredlights.build=35
-ec.cf=2242/839
-ec.version=deobf-1.7.10-2.2.73b129
-eio.cf=2219/296
-eio.version=1.7.10-2.2.1.276
+ec.version=1.10.2-0.4.1.58-beta
+eio.version=1.10.2-3.0.1.132_beta
 es.version=2.1.3.76
 fmp.version=1.1.0.308
 forestry.version=5.2.9.237

--- a/src/main/scala/li/cil/oc/common/item/Wrench.scala
+++ b/src/main/scala/li/cil/oc/common/item/Wrench.scala
@@ -22,7 +22,7 @@ import net.minecraft.world.World
   new Injectable.Interface(value = "buildcraft.api.tools.IToolWrench", modid = Mods.IDs.BuildCraftTools),
   new Injectable.Interface(value = "com.bluepowermod.api.misc.IScrewdriver", modid = Mods.IDs.BluePower),
   new Injectable.Interface(value = "cofh.api.item.IToolHammer", modid = Mods.IDs.CoFHItem),
-  new Injectable.Interface(value = "crazypants.enderio.tool.ITool", modid = Mods.IDs.EnderIO),
+  new Injectable.Interface(value = "crazypants.enderio.api.tool.ITool", modid = Mods.IDs.EnderIO),
   new Injectable.Interface(value = "mekanism.api.IMekWrench", modid = Mods.IDs.Mekanism),
   new Injectable.Interface(value = "powercrystals.minefactoryreloaded.api.IMFRHammer", modid = Mods.IDs.MineFactoryReloaded),
   new Injectable.Interface(value = "mrtjp.projectred.api.IScrewdriver", modid = Mods.IDs.ProjectRedCore),

--- a/src/main/scala/li/cil/oc/integration/Mods.scala
+++ b/src/main/scala/li/cil/oc/integration/Mods.scala
@@ -40,7 +40,7 @@ object Mods {
   val CraftingCosts = new SimpleMod(IDs.CraftingCosts)
   val DeepStorageUnit = new ClassBasedMod(IDs.DeepStorageUnit, "powercrystals.minefactoryreloaded.api.IDeepStorageUnit")()
   val ElectricalAge = new SimpleMod(IDs.ElectricalAge, providesPower = true)
-  val EnderIO = new SimpleMod(IDs.EnderIO, version = "@[2.2,2.3)")
+  val EnderIO = new SimpleMod(IDs.EnderIO, version = "@[1.10.2-3.0.1.132,)")
   val EnderStorage = new SimpleMod(IDs.EnderStorage)
   val ExtraCells = new SimpleMod(IDs.ExtraCells, version = "@[2.2.73,)")
   val Factorization = new SimpleMod(IDs.Factorization, providesPower = true)
@@ -108,7 +108,7 @@ object Mods {
     //    integration.cofh.tileentity.ModCoFHTileEntity,
     //    integration.cofh.transport.ModCoFHTransport,
     //    integration.ec.ModExtraCells,
-    //    integration.enderio.ModEnderIO,
+    integration.enderio.ModEnderIO,
     integration.enderstorage.ModEnderStorage,
     //    integration.dsu.ModDeepStorageUnit,
     integration.forestry.ModForestry,

--- a/src/main/scala/li/cil/oc/integration/enderio/EventHandlerEnderIO.scala
+++ b/src/main/scala/li/cil/oc/integration/enderio/EventHandlerEnderIO.scala
@@ -1,18 +1,19 @@
 package li.cil.oc.integration.enderio
 
-import crazypants.enderio.tool.ITool
+import crazypants.enderio.api.tool.ITool
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
+import net.minecraft.util.math.BlockPos
 
 object EventHandlerEnderIO {
-  def useWrench(player: EntityPlayer, x: Int, y: Int, z: Int, changeDurability: Boolean): Boolean = {
-    player.getHeldItem.getItem match {
+  def useWrench(player: EntityPlayer, pos: BlockPos, changeDurability: Boolean): Boolean = {
+    player.getHeldItemMainhand.getItem match {
       case wrench: ITool =>
         if (changeDurability) {
-          wrench.used(player.getHeldItem, player, x, y, z)
+          wrench.used(player.getHeldItemMainhand, player, pos)
           true
         }
-        else wrench.canUse(player.getHeldItem, player, x, y, z)
+        else wrench.canUse(player.getHeldItemMainhand, player, pos)
       case _ => false
     }
   }

--- a/src/main/scala/li/cil/oc/integration/enderio/ModEnderIO.scala
+++ b/src/main/scala/li/cil/oc/integration/enderio/ModEnderIO.scala
@@ -10,5 +10,7 @@ object ModEnderIO extends ModProxy {
   override def initialize(): Unit = {
     api.IMC.registerWrenchTool("li.cil.oc.integration.enderio.EventHandlerEnderIO.useWrench")
     api.IMC.registerWrenchToolCheck("li.cil.oc.integration.enderio.EventHandlerEnderIO.isWrench")
+
+    ProviderEnderIO.init()
   }
 }

--- a/src/main/scala/li/cil/oc/integration/enderio/ProviderEnderIO.scala
+++ b/src/main/scala/li/cil/oc/integration/enderio/ProviderEnderIO.scala
@@ -1,0 +1,67 @@
+package li.cil.oc.integration.enderio
+
+import java.util
+
+import com.enderio.core.common.util.DyeColor
+import crazypants.enderio.conduit.IConduitBundle
+import crazypants.enderio.conduit.redstone.IRedstoneConduit
+import crazypants.enderio.conduit.redstone.ISignalProvider
+import crazypants.enderio.conduit.redstone.InsulatedRedstoneConduit
+import crazypants.enderio.conduit.redstone.Signal
+import li.cil.oc.common.tileentity.traits.BundledRedstoneAware
+import li.cil.oc.integration.util.BundledRedstone
+import li.cil.oc.integration.util.BundledRedstone.RedstoneProvider
+import li.cil.oc.util.BlockPosition
+import li.cil.oc.util.ExtendedWorld._
+import net.minecraft.util.EnumFacing
+import net.minecraft.util.math.BlockPos
+import net.minecraft.world.World
+
+import scala.collection.convert.WrapAsJava._
+import scala.collection.convert.WrapAsScala._
+
+/**
+  * @author Vexatos
+  */
+object ProviderEnderIO extends RedstoneProvider with ISignalProvider {
+  def init() {
+    BundledRedstone.addProvider(this)
+    InsulatedRedstoneConduit.addSignalProvider(this)
+  }
+
+  override def computeInput(pos: BlockPosition, side: EnumFacing): Int = 0
+
+  override def computeBundledInput(pos: BlockPosition, side: EnumFacing): Array[Int] = {
+    pos.world.get.getTileEntity(pos.offset(side)) match {
+      case bundle: IConduitBundle if bundle.hasType(classOf[IRedstoneConduit]) =>
+        bundle.getConduit(classOf[IRedstoneConduit]) match {
+          case conduit: IRedstoneConduit =>
+            val res = Array.fill[Int](16)(0)
+            conduit.getNetworkOutputs(side.getOpposite).groupBy(15 - _.color.ordinal).foreach {
+              case (color, signals) => res(color) = signals.maxBy(_.strength).strength
+              case _ =>
+            }
+            res
+          case _ => null
+        }
+      case _ => null
+    }
+  }
+
+  override def connectsToNetwork(world: World, pos: BlockPos, side: EnumFacing): Boolean = {
+    world.getTileEntity(pos) match {
+      case tile: BundledRedstoneAware => tile.isOutputEnabled
+      case _ => false
+    }
+  }
+
+  override def getNetworkInputs(world: World, pos: BlockPos, side: EnumFacing): util.Set[Signal] = {
+    world.getTileEntity(pos) match {
+      case tile: BundledRedstoneAware =>
+        tile.bundledOutput(side).zipWithIndex.map {
+          case (strength, i) => new Signal(pos, side.getOpposite, strength, DyeColor.fromIndex(15 - i))
+        }.toSet[Signal]
+      case _ => null
+    }
+  }
+}


### PR DESCRIPTION
Closes #613.

Dependencies are on `deobfCompile` right now as the mod is useful for testing. I can change it to `provided` in case you prefer that.