### PR TITLE
Allow multiple environment providers to return environments for the same ItemStack.

### DIFF
--- a/src/main/java/li/cil/oc/api/Driver.java
+++ b/src/main/java/li/cil/oc/api/Driver.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * This API allows registering new drivers with the mod.
@@ -219,10 +220,28 @@ public final class Driver {
      *
      * @param stack the item stack to get the environment type for.
      * @return the type of environment associated with the stack, or <tt>null</tt>.
+     * @deprecated Use {@link #environmentsFor(ItemStack)} instead.
      */
+    @Deprecated
     public static Class<?> environmentFor(ItemStack stack) {
         if (API.driver != null)
             return API.driver.environmentFor(stack);
+        return null;
+    }
+
+    /**
+     * Looks up the environments associated with the specified item stack.
+     * <p/>
+     * This will use the registered {@link EnvironmentProvider}s to find
+     * environment types for the specified item stack. If none can be
+     * found, returns an empty Set.
+     *
+     * @param stack the item stack to get the environment type for.
+     * @return the type of environment associated with the stack, or an empty Set, or null if the API is not present.
+     */
+    public static Set<Class<?>> environmentsFor(ItemStack stack) {
+        if (API.driver != null)
+            return API.driver.environmentsFor(stack);
         return null;
     }
 

--- a/src/main/java/li/cil/oc/api/detail/DriverAPI.java
+++ b/src/main/java/li/cil/oc/api/detail/DriverAPI.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.Collection;
+import java.util.Set;
 
 public interface DriverAPI {
     /**
@@ -169,8 +170,22 @@ public interface DriverAPI {
      *
      * @param stack the item stack to get the environment type for.
      * @return the type of environment associated with the stack, or <tt>null</tt>.
+     * @deprecated Use {@link #environmentsFor(ItemStack)} instead.
      */
+    @Deprecated
     Class<?> environmentFor(ItemStack stack);
+
+    /**
+     * Looks up the environments associated with the specified item stack.
+     * <p/>
+     * This will use the registered {@link EnvironmentProvider}s to find
+     * environment types for the specified item stack. If none can be
+     * found, returns an empty Set.
+     *
+     * @param stack the item stack to get the environment type for.
+     * @return the type of environment associated with the stack, or an empty Set.
+     */
+    Set<Class<?>> environmentsFor(ItemStack stack);
 
     /**
      * Get an inventory implementation providing access to an item inventory.

--- a/src/main/scala/li/cil/oc/integration/nei/CallbackDocHandler.scala
+++ b/src/main/scala/li/cil/oc/integration/nei/CallbackDocHandler.scala
@@ -25,7 +25,7 @@ class CallbackDocHandler(pages: Option[Array[String]]) extends PagedUsageHandler
     if (input == "item") {
       ingredients.collect {
         case stack: ItemStack if stack.getItem != null =>
-          val callbacks = getCallbacks(api.Driver.environmentFor(stack)).toBuffer
+          val callbacks = api.Driver.environmentsFor(stack).flatMap(getCallbacks).toBuffer
 
           // TODO remove in OC 1.7
           if (callbacks.isEmpty) {

--- a/src/main/scala/li/cil/oc/server/driver/Registry.scala
+++ b/src/main/scala/li/cil/oc/server/driver/Registry.scala
@@ -136,11 +136,14 @@ private[oc] object Registry extends api.detail.DriverAPI {
     if (stack != null) items.find(_.worksWith(stack)).orNull
     else null
 
+  @Deprecated
   override def environmentFor(stack: ItemStack): Class[_] = {
     environmentProviders.map(provider => provider.getEnvironment(stack)).collectFirst {
       case clazz: Class[_] => clazz
     }.orNull
   }
+
+  override def environmentsFor(stack: ItemStack): util.Set[Class[_]] = environmentProviders.map(_.getEnvironment(stack)).filter(_ != null).toSet[Class[_]]
 
   override def inventoryFor(stack: ItemStack, player: EntityPlayer): IInventory = {
     inventoryProviders.find(provider => provider.worksWith(stack, player)).


### PR DESCRIPTION
Deprecated the old method. I don't know if any mod actually uses it.

This is useful in case of environments accessed through Drivers, as there might be multiple environments for a single block.