### PR TITLE
Fixed RedLogic redstone input reading.

### DIFF
--- a/src/main/scala/li/cil/oc/integration/redlogic/ModRedLogic.scala
+++ b/src/main/scala/li/cil/oc/integration/redlogic/ModRedLogic.scala
@@ -19,7 +19,7 @@ object ModRedLogic extends ModProxy with RedstoneProvider {
   }
 
   override def computeInput(pos: BlockPosition, side: ForgeDirection): Int = {
-    pos.world.get.getTileEntity(pos) match {
+    pos.world.get.getTileEntity(pos.offset(side)) match {
       case emitter: IRedstoneEmitter =>
         var strength = 0
         for (i <- -1 to 5) {


### PR DESCRIPTION
Should fix #2137. Should also close #1599 as that appears to be the same issue.

If I'm not mistaken, `pos` in `computeInput` is the position of the receiver, i.e. the computer case, so the input actually needs to be offset. Right now, the case is basically reading its own output from the opposite side whenever redlogic was installed.