### PR TITLE
Fix kernel naming in LuaJ

### DIFF
--- a/src/main/scala/li/cil/oc/server/machine/luaj/LuaJLuaArchitecture.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luaj/LuaJLuaArchitecture.scala
@@ -232,7 +232,7 @@ class LuaJLuaArchitecture(val machine: api.machine.Machine) extends Architecture
 
     recomputeMemory(machine.host.internalComponents)
 
-    val kernel = lua.load(classOf[Machine].getResourceAsStream(Settings.scriptPath + "machine.lua"), "=kernel", "t", lua)
+    val kernel = lua.load(classOf[Machine].getResourceAsStream(Settings.scriptPath + "machine.lua"), "=machine", "t", lua)
     thread = new LuaThread(lua, kernel) // Left as the first value on the stack.
 
     true


### PR DESCRIPTION
Native Lua loads machine.lua as "=machine" but LuaJ uses "=kernel" instead.

This PR fixes that naming inconsistency.