### PR TITLE
Admin-controllable synchronous execution support

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -269,20 +269,20 @@ opencomputers {
     # Failure to heed this warning may lead to severe world lag.
     sync {
 
-      # A list of entities that are initially considered "secure" for
+      # A list of entities that are initially considered "trusted" for
       # synchronous execution purposes.
       # Each entry in the list is one of:
       # - The SHA-256 hash of an EEPROM, in base64 format
       # - The name of an architecture
       whitelist: []
 
-      # Whether even non-"secure" computers can request synchronous operation.
+      # Whether even "untrusted" computers can request synchronous operation.
       insecure: false
 
-      # Whether only microcontrollers can be considered "secure".
+      # Whether only microcontrollers can be considered "trusted".
       microcontrollerOnly: false
 
-      # Whether to allow Lua programs on secure computers to increase their
+      # Whether to allow Lua programs on trusted computers to increase their
       # execution timeout.
       # DOUBLE WARNING! Of all the options in this section, this is the most
       # dangerous! Setting this allows incorrect or malicious Lua code (which

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -276,6 +276,11 @@ opencomputers {
       # - The name of an architecture
       whitelist: []
 
+      # A secret string that can be read only by "trusted" computers. This is
+      # designed to allow writing hash-based "trusted bootloaders" whose secret
+      # nonces cannot be recovered by simply reading the EEPROM.
+      trustedSecret: ""
+
       # Whether even "untrusted" computers can request synchronous operation.
       insecure: false
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -263,6 +263,32 @@ opencomputers {
       # IN PARTICULAR, DO NOT REPORT ISSUES AFTER MESSING WITH THIS!
       maxTotalRam: 67108864
     }
+
+    # Settings related to synchronous execution.
+    # IMPORTANT: DO NOT MESS WITH THIS UNLESS YOU KNOW WHAT YOU'RE DOING.
+    # Failure to heed this warning may lead to severe world lag.
+    sync {
+
+      # A list of entities that are initially considered "secure" for
+      # synchronous execution purposes.
+      # Each entry in the list is one of:
+      # - The SHA-256 hash of an EEPROM, in base64 format
+      # - The name of an architecture
+      whitelist: []
+
+      # Whether even non-"secure" computers can request synchronous operation.
+      insecure: false
+
+      # Whether only microcontrollers can be considered "secure".
+      microcontrollerOnly: false
+
+      # Whether to allow Lua programs on secure computers to increase their
+      # execution timeout.
+      # DOUBLE WARNING! Of all the options in this section, this is the most
+      # dangerous! Setting this allows incorrect or malicious Lua code (which
+      # has been accidentally whitelisted) to HANG THE SERVER INDEFINITELY!
+      allowOverrideTimeout: false
+    }
   }
 
   # Robot related settings, what they may do and general balancing.

--- a/src/main/resources/assets/opencomputers/lua/machine.lua
+++ b/src/main/resources/assets/opencomputers/lua/machine.lua
@@ -1,3 +1,4 @@
+local customTimeout = nil
 local hookInterval = 100
 local deadline = math.huge
 local hitDeadline = false
@@ -11,8 +12,6 @@ local function checkDeadline()
     error("too long without yielding", 0)
   end
 end
-
-local customTimeout = nil
 
 -------------------------------------------------------------------------------
 
@@ -1362,9 +1361,7 @@ local libcomputer = {
     end
   end,
   setCustomTimeout = function(timeout)
-     if timeout ~= nil then
-        checkArg(1, timeout, "number")
-     end
+     checkArg(1, timeout, "number", "nil")
      customTimeout = timeout
   end
 }
@@ -1437,12 +1434,12 @@ local function main()
   while true do
     -- Allow custom timeouts under either of the following circumstances:
     -- * Timeout is SHORTER than the configured timeout
-    -- * Custom timeouts are enabled in the server config AND we are Secure
+    -- * Custom timeouts are enabled in the server config AND we are Trusted
     if customTimeout
         and (customTimeout < system.timeout() or
           (system.mayOverrideTimeout
            and system.mayOverrideTimeout()
-           and libcomponent.invoke(computer.address(), "isSecure"))) then
+           and libcomponent.invoke(computer.address(), "isTrusted"))) then
       deadline = computer.realTime() + customTimeout
     else
       deadline = computer.realTime() + system.timeout()

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -84,6 +84,7 @@ class Settings(val config: Config) {
   val syncMicrocontrollerOnly = config.getBoolean("computer.sync.microcontrollerOnly")
   val syncAllowOverrideTimeout = config.getBoolean("computer.sync.allowOverrideTimeout")
   val anyoneCanSync = config.getBoolean("computer.sync.insecure")
+  var trustedSecret = config.getString("computer.sync.trustedSecret")
 
   // computer.lua
   val allowBytecode = config.getBoolean("computer.lua.allowBytecode")

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -80,6 +80,10 @@ class Settings(val config: Config) {
   val maxUsernameLength = config.getInt("computer.maxUsernameLength") max 0
   val eraseTmpOnReboot = config.getBoolean("computer.eraseTmpOnReboot")
   val executionDelay = config.getInt("computer.executionDelay") max 0
+  val syncWhitelist = config.getStringList("computer.sync.whitelist")
+  val syncMicrocontrollerOnly = config.getBoolean("computer.sync.microcontrollerOnly")
+  val syncAllowOverrideTimeout = config.getBoolean("computer.sync.allowOverrideTimeout")
+  val anyoneCanSync = config.getBoolean("computer.sync.insecure")
 
   // computer.lua
   val allowBytecode = config.getBoolean("computer.lua.allowBytecode")

--- a/src/main/scala/li/cil/oc/server/machine/Machine.scala
+++ b/src/main/scala/li/cil/oc/server/machine/Machine.scala
@@ -1014,6 +1014,7 @@ class Machine(val host: MachineHost) extends prefab.ManagedEnvironment with mach
     state.push(value)
     if (value == Machine.State.Yielded || value == Machine.State.SynchronizedReturn) {
       remainIdle = 0
+      curTrustState = wantTrustState
       isSynchronous = wantToBeSynchronous
       if(!isSynchronous)
         Machine.threadPool.schedule(this, Settings.get.executionDelay, TimeUnit.MILLISECONDS)

--- a/src/main/scala/li/cil/oc/server/machine/luac/SystemAPI.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luac/SystemAPI.scala
@@ -46,6 +46,13 @@ class SystemAPI(owner: NativeLuaArchitecture) extends NativeLuaAPI(owner) {
     })
     lua.setField(-2, "timeout")
 
+    // Whether Secure machines should be allowed to override timeouts.
+    lua.pushScalaFunction(lua => {
+      lua.pushBoolean(Settings.get.syncAllowOverrideTimeout)
+      1
+    })
+    lua.setField(-2, "mayOverrideTimeout")
+
     lua.setGlobal("system")
   }
 }

--- a/src/main/scala/li/cil/oc/server/machine/luaj/SystemAPI.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luaj/SystemAPI.scala
@@ -18,6 +18,9 @@ class SystemAPI(owner: LuaJLuaArchitecture) extends LuaJAPI(owner) {
     // How long programs may run without yielding before we stop them.
     system.set("timeout", (_: Varargs) => LuaValue.valueOf(Settings.get.timeout))
 
+    // Whether Secure machines should be allowed to override timeouts.
+    system.set("mayOverrideTimeout", (_: Varargs) => LuaValue.valueOf(Settings.get.syncAllowOverrideTimeout))
+
     lua.set("system", system)
   }
 }


### PR DESCRIPTION
OpenComputers computers execute in worker threads separate from the world thread. 99.9% of the time, this is a _very_ good thing. Sometimes, however, precise tick-perfect timing is needed. Nuclear reactor controllers, note block playback engines, and Endergenic Generators are all examples of things where tick jitter can have negative consequences. (Obviously, some of these have higher stakes than others.)

This PR adds the ability for computers to request synchronous execution, and be executed on the world thread. Since doing this across the board would be suicidal, it also adds features that allow admins to control where it can be used.

These changes were inspired by @gamax92 's experiment earlier today, and guided by feedback in \#oc. @gamax92 was _incredibly_ helpful in tracking down almost every change that needed to be made. Skye requested the `microcontrollerOnly` option.

Defaults
========

Unless specifically configured otherwise, no computer is ever Secure, and a Secure boot is required to be synchronous. With an unchanged configuration, the only change from this PR is the ability for computers to voluntarily shorten their own execution timeout.

Secure Boot
===========

There is a new option in the configuration file, `computer.sync.whitelist`. When a computer first boots up, if its architecture name or EEPROM checksum is in that whitelist, it boots into a Secure state. Otherwise, it boots into an Insecure state. This allows admins to strictly control what code is given the dangerous powers this PR adds. (If the config setting `computer.sync.microcontrollerOnly` is true, only Microcontrollers can be Secure.)

Secure computers are allowed to request synchronous operation. If the config setting `computer.sync.allowOverrideTimeout` is true, Secure computers can also increase their execution timeout. (Both Secure and Insecure computers can _decrease_ it, regardless of this config option.)

A Secure computer may enter the Insecure state at will with `component.computer.giveUpSyncPrivileges()`. Once it is Insecure, the only way for it to become Secure again is to reboot with a whitelisted architecture or EEPROM. This would allow "secure bootloaders" to pass Secure status only to trusted code.

Whitelisting a specific EEPROM is useful if the admin has vetted it as being "safe"; either a bootloader that only boots admin-signed code, or a self-contained "safe" program on its own. Whitelisting a specific architecture is useful if the architecture in question has its own lag-friendly execution caps. (With OC-ARM, for instance, four computers configured to run at 100x the normal clock rate, running busy looping test programs, only added ~8 milliseconds to each tick.) Either way, the computer doesn't _actually_ become synchronous until synchronous operation is requested.

Synchronous Operation
======================

Computers may request synchronous operation with `component.computer.setSyncMode(true)`. Secure computers may always request synchronous operation. Insecure computers may also do so if the (dangerous!) config setting `computer.sync.insecure` is true.

A synchronous computer is executed on the world thread rather than in a worker thread. This means that it can respond to events in the world with tick-perfect timing. This _also_ means it can horribly lag the world if its execution takes too long, which is why the Secure Boot feature is there.

Computers that wish to do so can return to asynchronous operation with `component.computer.setSyncMode(false)`. If a computer is in synchronous mode and `computer.sync.insecure` is false and `component.computer.giveUpSyncPrivileges()` is called, that will also cause it to become asynchronous.

Custom Timeouts
===============

To help mitigate potential timeout-related problems, this PR also adds a `computer.setCustomTimeout` function to `machine.lua`. Normally, only _shorter_ timeouts than the configured default are honored; this allows synchronous computers to voluntarily limit their world-lagging potential. If the config option `computer.sync.allowOverrideTimeout` is set, Secure computers can also _lengthen_ the timeout. They should only do this when the alternative is oblivion; e.g. nuclear reactor control computers.