### PR TITLE
Fix robots duplicating with SpongeForge.

### DIFF
--- a/src/main/scala/li/cil/oc/server/machine/Machine.scala
+++ b/src/main/scala/li/cil/oc/server/machine/Machine.scala
@@ -765,7 +765,11 @@ class Machine(val host: MachineHost) extends prefab.ManagedEnvironment with mach
   })
 
   override def save(nbt: NBTTagCompound): Unit = Machine.this.synchronized(state.synchronized {
-    assert(!isExecuting) // Lock on 'this' should guarantee this.
+    // The lock on 'this' should guarantee that this never happens regularly.
+    // If something other than regular saving tries to save while we are executing code,
+    // e.g. SpongeForge saving during robot.move due to block changes being captured,
+    // just don't save this at all. What could possibly go wrong?
+    if(isExecuting) return
 
     if (SaveHandler.savingForClients) {
       return


### PR DESCRIPTION
At least until a server protection mod blocks the movement improperly. But that's their fault.

Thanks to @bloodmc for helping me find this. This is most likely better than crashing.