### PR TITLE
term safe slow write, fix pastebin get, low mem loadfile fix

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/pastebin.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/pastebin.lua
@@ -21,7 +21,7 @@ local function get(pasteId, filename)
   end
 
   io.write("Downloading from pastebin.com... ")
-  local url = "http://pastebin.com/raw.php?i=" .. pasteId
+  local url = "http://pastebin.com/raw/" .. pasteId
   local result, response = pcall(internet.request, url)
   if result then
     io.write("success.\n")

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/00_base.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/00_base.lua
@@ -15,7 +15,8 @@ function loadfile(filename, mode, env)
     end
     table.insert(buffer, data)
   end
-  buffer = table.concat(buffer):gsub("^#![^\n]+", "") -- remove shebang if any
+  buffer[1] = (buffer[1] or ""):gsub("^#![^\n]+", "") -- remove shebang if any
+  buffer = table.concat(buffer)
   return load(buffer, "=" .. filename, mode, env)
 end
 

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
@@ -390,7 +390,13 @@ function term.drawText(value, wrap, window)
   local function scroll(_sy,_y)
     return _sy + term.internal.scroll(window,_y-h), math.min(_y,h)
   end
+  local uptime = computer.uptime
+  local last_sleep = uptime()
   while index <= vlen do
+    if uptime() - last_sleep > 4 then
+      os.sleep(0)
+      last_sleep = uptime()
+    end
     local si,ei = value:find("[\t\r\n\a]", index)
     si = si or vlen+1
     if index==si then
@@ -401,7 +407,7 @@ function term.drawText(value, wrap, window)
         x,y=1,y+1
         sy,y = scroll(sy,y)
       elseif delim=="\a" and not beeped then
-        require("computer").beep()
+        computer.beep()
         beeped = true
       end
       cr_last = delim == "\r"


### PR DESCRIPTION
added a timeout check in term.drawText in case of very large draw loops
fixed pastebin to use correct raw url instead of redirecting url
added minor memory improvement to loadfile, will improve loading very large files
