### PR TITLE
Add SHODAN to list of robot names

### DIFF
--- a/src/main/resources/assets/opencomputers/robot.names
+++ b/src/main/resources/assets/opencomputers/robot.names
@@ -88,6 +88,7 @@ Robby              # Forbidden Planet
 Roomba             # Under your couch... wait.
 Rosie              # The Jetsons
 Shakey             # The first general-purpose mobile robot that could reason about its actions.
+SHODAN             # System Shock
 Skynet             # Terminator
 Space Core         # Portal
 SpiritedDusty      # Contributor


### PR DESCRIPTION
Adds a recognizable AI not on this list, SHODAN from the System Shock games.