### PR TITLE
Added maxPacketParts method to the Network Card

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/NetworkCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/NetworkCard.scala
@@ -110,6 +110,9 @@ class NetworkCard(val host: EnvironmentHost) extends prefab.ManagedEnvironment w
   @Callback(direct = true, doc = """function():number -- Gets the maximum packet size (config setting).""")
   def maxPacketSize(context: Context, args: Arguments): Array[AnyRef] = result(Settings.get.maxNetworkPacketSize)
 
+  @Callback(direct = true, doc = """function():number -- Gets the maximum number of packet parts (config setting).""")
+  def maxPacketParts(context: Context, args: Arguments): Array[AnyRef] = result(Settings.get.maxNetworkPacketParts)
+  
   @Callback(direct = true, doc = """function():string, boolean -- Get the current wake-up message.""")
   def getWakeMessage(context: Context, args: Arguments): Array[AnyRef] = result(wakeMessage.orNull, wakeMessageFuzzy)
 


### PR DESCRIPTION
Ref #2294 

This adds a method to get the maximum number of parts a packet can have. Simple as that.