### PR TITLE
fix insertIntoInventorySlot not updating input stack in simulate mode

### DIFF
--- a/src/main/scala/li/cil/oc/util/InventoryUtils.scala
+++ b/src/main/scala/li/cil/oc/util/InventoryUtils.scala
@@ -94,8 +94,12 @@ object InventoryUtils {
         val toInsert = stack.copy()
         toInsert.stackSize = amount
         inventory.insertItem(slot, toInsert, simulate) match {
-          case remaining: ItemStack => remaining.stackSize < amount
-          case _ => true
+          case remaining: ItemStack =>
+            stack.stackSize -= amount - remaining.stackSize
+            remaining.stackSize < amount
+          case _ =>
+            stack.stackSize -= amount
+            true
         }
       } else {
         val toInsert = stack.splitStack(amount)


### PR DESCRIPTION
The use from `hasRoomForItemStack` expects `insertIntoInventory` to update the input stack, even when `simulate = true`. Whether this is a valid use-case, or if the check should be rewritten, is for you to decide, but this fixes that usecase and fixes trading.