### PR TITLE
openos 1.6.4

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/grep.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/grep.lua
@@ -9,6 +9,7 @@ https://raw.githubusercontent.com/OpenPrograms/Wobbo-Programs/master/grep/grep.l
 local fs = require("filesystem")
 local shell = require("shell")
 local tty = require("tty")
+local computer = require("computer")
 
 -- Process the command line arguments
 
@@ -298,7 +299,14 @@ local function test(m,p)
     m.close = true
   end
 end
+
+local uptime = computer.uptime
+local last_sleep = uptime()
 for meta,status in readLines() do
+  if uptime() - last_sleep > 1 then
+    os.sleep(0)
+    last_sleep = uptime()
+  end
   if not meta then
     if type(status) == 'table' then if flush then
       flush(status) end -- this was the last object, closing out

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/lua.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/lua.lua
@@ -22,6 +22,6 @@ end
 
 buffer, reason = pcall(script, table.unpack(args, 2))
 if not buffer then
-  io.stderr:write(reason, "\n")
+  io.stderr:write(type(reason) == "table" and reason.reason or tostring(reason), "\n")
   os.exit(false)
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/02_os.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/02_os.lua
@@ -48,7 +48,7 @@ end
 function os.tmpname()
   local path = os.getenv("TMPDIR") or "/tmp"
   if fs.exists(path) then
-    for i = 1, 10 do
+    for _ = 1, 10 do
       local name = fs.concat(path, tostring(math.random(1, 0x7FFFFFFF)))
       if not fs.exists(name) then
         return name

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/03_io.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/03_io.lua
@@ -64,7 +64,7 @@ core_stdout.close = stdinStream.close
 core_stderr.close = stdinStream.close
 
 local io_mt = getmetatable(io) or {}
-io_mt.__index = function(t, k)
+io_mt.__index = function(_, k)
   return
     k == 'stdin' and io.input() or
     k == 'stdout' and io.output() or

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/91_gpu.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/91_gpu.lua
@@ -5,10 +5,14 @@ local function onComponentAvailable(_, componentType)
   if (componentType == "screen" and component.isAvailable("gpu")) or
      (componentType == "gpu" and component.isAvailable("screen"))
   then
-    component.gpu.bind(component.screen.address)
-    local depth = math.floor(2^(component.gpu.getDepth()))
+    local gpu, screen = component.gpu, component.screen
+    local screen_address = screen.address
+    if gpu.getScreen() ~= screen_address then
+      gpu.bind(screen_address)
+    end
+    local depth = math.floor(2^(gpu.getDepth()))
     os.setenv("TERM", "term-"..depth.."color")
-    require("computer").pushSignal("gpu_bound", component.gpu.address, component.screen.address)
+    require("computer").pushSignal("gpu_bound", gpu.address, screen_address)
   end
 end
 

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/94_shell.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/94_shell.lua
@@ -1,3 +1,4 @@
 -- there doesn't seem to be a reason to update $HOSTNAME after the init signal
 -- as user space /etc/profile comes after this point anyways
 loadfile("/bin/hostname.lua")("--update")
+os.setenv("SHELL","/bin/sh.lua")

--- a/src/main/resources/assets/opencomputers/loot/openos/etc/profile
+++ b/src/main/resources/assets/opencomputers/loot/openos/etc/profile
@@ -18,7 +18,6 @@ set MANPATH=/usr/man:.
 set PAGER=/bin/more
 set PS1='$HOSTNAME$HOSTNAME_SEPARATOR$PWD # '
 set PWD=/
-set SHELL=/bin/sh
 set LS_COLORS="{FILE=0xFFFFFF,DIR=0x66CCFF,LINK=0xFFAA00,['*.lua']=0x00FF00}"
 
 cd $HOME

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/io.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/io.lua
@@ -77,7 +77,7 @@ function io.error(file)
 end
 
 function io.popen(prog, mode, env)
-  return require('pipes').popen(prog, mode, env)
+  return require("pipes").popen(prog, mode, env)
 end
 
 function io.read(...)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/keyboard.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/keyboard.lua
@@ -82,13 +82,6 @@ end
 
 -------------------------------------------------------------------------------
 
-setmetatable(keyboard.keys,
-{
-  __index = function(tbl, key)
-    setmetatable(tbl, nil)
-    dofile("/opt/core/full_keyboard.lua")
-    return tbl[key] -- some keyboard keys are handled by __index by design
-  end
-})
+require("package").delay(keyboard.keys, "/opt/core/full_keyboard.lua")
 
 return keyboard

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/package.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/package.lua
@@ -69,6 +69,17 @@ function require(module)
   end
 end
 
+function package.delay(lib, file)
+  setmetatable(lib, 
+  {
+    __index = function(tbl, key)
+      setmetatable(tbl, nil)
+      dofile(file)
+      return tbl[key]
+    end
+  })
+end
+
 -------------------------------------------------------------------------------
 
 return package

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/pipes.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/pipes.lua
@@ -184,7 +184,8 @@ function pipes.createCoroutineStack(fp, init, name)
     if current_index then
       -- current should be waiting for yield
       pco.next = thread
-      return true, _co.yield(...) -- pass args to resume next
+      local t = table.pack(_co.yield(...)) -- pass args to resume next
+      return pco.last == nil and true or pco.last, table.unpack(t,1,t.n)
     else
       -- the stack is not running
       pco.next = false
@@ -202,6 +203,7 @@ function pipes.createCoroutineStack(fp, init, name)
         if pco.next and pco.next ~= thread then
           local next = pco.next
           pco.next = false
+          pco.last = yield_args[1]
           return pco.resume(next, table.unpack(yield_args,2,yield_args.n))
         end
       end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/process.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/process.lua
@@ -27,7 +27,6 @@ function process.load(path, env, init, name)
   checkArg(4, name, "string", "nil")
 
   assert(type(path) == "string" or env == nil, "process cannot load function environemnts")
-  name = name or ""
 
   local p = process.findProcess()
   env = env or p.env
@@ -37,13 +36,7 @@ function process.load(path, env, init, name)
       local fs, shell = require("filesystem"), require("shell")
       local program, reason = shell.resolve(path, "lua")
       if not program then
-        if fs.isDirectory(shell.resolve(path)) then
-          io.stderr:write(path .. ": is a directory\n")
-          return 126
-        end
-        local handler = require("tools/programLocations")
-        handler.reportNotFound(path, reason)
-        return 127
+        return require("tools/programLocations").reportNotFound(path, reason)
       end
       os.setenv("_", program)
       local f = fs.open(program)
@@ -51,18 +44,12 @@ function process.load(path, env, init, name)
         local shebang = (f:read(1024) or ""):match("^#!([^\n]+)")
         f:close()
         if shebang then
-          local result = table.pack(shell.execute(shebang:gsub("%s",""), env, program, ...))
-          assert(result[1], result[2])
-          return table.unpack(result)
+          path = shebang:gsub("%s","")
+          return code(program, ...)
         end
       end
-      local command
-      command, reason = loadfile(program, "bt", env)
-      if not command then
-        io.stderr:write(program, " ", reason or "", "\n")
-        return 128
-      end
-      return command(...)
+      -- local command
+      return assert(loadfile(program, "bt", env))(...)
     end
   else -- path is code
     code = path
@@ -74,7 +61,6 @@ function process.load(path, env, init, name)
     local result =
     {
       xpcall(function(...)
-          os.setenv("_", name)
           init = init or function(...) return ... end
           return code(init(...))
         end,
@@ -91,7 +77,7 @@ function process.load(path, env, init, name)
           return 128 -- syserr
         end, ...)
     }
-    process.internal.close(thread)
+    process.internal.close(thread, result)
     --result[1] is false if the exception handler also crashed
     if not result[1] and type(result[2]) ~= "number" then
       require("event").onError(string.format("process library exception handler crashed: %s", tostring(result[2])))
@@ -101,7 +87,7 @@ function process.load(path, env, init, name)
   local new_proc =
   {
     path = path,
-    command = name,
+    command = name or tostring(path),
     env = env,
     data =
     {
@@ -145,11 +131,12 @@ end
 --table of undocumented api subject to change and intended for internal use
 process.internal = {}
 --this is a future stub for a more complete method to kill a process
-function process.internal.close(thread)
+function process.internal.close(thread, result)
   checkArg(1,thread,"thread")
   local pdata = process.info(thread).data
-  for k,v in pairs(pdata.handles) do
-    v:close()
+  pdata.result = result
+  for _,v in pairs(pdata.handles) do
+    pcall(v.close, v)
   end
   process.list[thread] = nil
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/serialization.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/serialization.lua
@@ -126,7 +126,7 @@ end
 
 function serialization.unserialize(data)
   checkArg(1, data, "string")
-  local result, reason = load("return " .. data, "=data", _, {math={huge=math.huge}})
+  local result, reason = load("return " .. data, "=data", nil, {math={huge=math.huge}})
   if not result then
     return nil, reason
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/sh.lua
@@ -16,7 +16,6 @@ local isWordOf = sh.internal.isWordOf
 
 --SH API
 
-sh.internal.globbers = {{"*",".*"},{"?","."}}
 sh.internal.ec = {}
 sh.internal.ec.parseCommand = 127
 sh.internal.ec.last = 0
@@ -25,22 +24,21 @@ function sh.getLastExitCode()
   return sh.internal.ec.last
 end
 
-function sh.internal.command_passed(ec)
-  local code = sh.internal.command_result_as_code(ec)
-  return code == 0
-end
-
-function sh.internal.command_result_as_code(ec)
+function sh.internal.command_result_as_code(ec, reason)
   -- convert lua result to bash ec
+  local code
   if ec == false then
-    return 1
+    code = 1
   elseif ec == nil or ec == true then
-    return 0
+    code = 0
   elseif type(ec) ~= "number" then
-    return 2 -- illegal number
+    code = 2 -- illegal number
   else
-    return ec
+    code = ec
   end
+
+  if reason and code ~= 0 then io.stderr:write(reason, "\n") end
+  return code
 end
 
 function sh.internal.resolveActions(input, resolver, resolved)
@@ -143,94 +141,6 @@ function sh.expand(value)
   return expanded
 end
 
--- expand all parts if interpreted (not literal)
--- i.e '' is literal, "" and `` are interpreted
--- called only by sh.internal.evaluate
-function sh.internal.expand(word)
-  if #word == 0 then return {} end
-  local result = ''
-  for i=1,#word do
-    local part = word[i]
-    local next = part.txt
-    local quoted = part.qr
-    local literal, keep_whitespace, sub
-    if quoted then
-      literal = quoted[3]
-      keep_whitespace = quoted[1] == '"'
-      sub = quoted[1]:match('`') or next:find('`') and ''
-    end
-    if not literal then
-      next = sh.expand(next)
-      if sub then
-        next = sh.internal.parse_sub(sub .. next .. sub)
-      end
-      if not keep_whitespace then
-        next = text.trim((next:gsub("%s+", " ")))
-      end
-    end
-    result = result .. next
-  end
-  return {result}
-end
-
--- expand to files in path, or try key substitution
--- word is a list of metadata-filled word parts
--- note: text.internal.words(string) returns an array of these words
-function sh.internal.evaluate(word)
-  checkArg(1, word, "table")
-  local glob_pattern = ''
-  local has_globits = false
-  for i=1,#word do
-    local part = word[i]
-    local next = part.txt
-    if not part.qr then
-      local escaped = text.escapeMagic(next)
-      next = escaped
-      for _,glob_rule in ipairs(sh.internal.globbers) do
-        next = next:gsub("%%%"..glob_rule[1], glob_rule[2])
-        while true do
-          local prev = next
-          next = next:gsub(text.escapeMagic(glob_rule[2]):rep(2), glob_rule[2])
-          if prev == next then
-            break
-          end
-        end
-      end
-      if next ~= escaped then
-        has_globits = true
-      end
-    end
-    glob_pattern = glob_pattern .. next
-  end
-  if not has_globits then
-    return sh.internal.expand(word)
-  end
-  local globs = sh.internal.glob(glob_pattern)
-  return #globs == 0 and sh.internal.expand(word) or globs
-end
-
-function sh.hintHandler(full_line, cursor)
-  return sh.internal.hintHandlerImpl(full_line, cursor)
-end
-
-function sh.internal.parseCommand(words)
-  checkArg(1, words, "table")
-  if #words == 0 then
-    return nil
-  end
-  -- evaluated words
-  local ewords = {}
-  -- the arguments have < or > which require parsing for redirection
-  local has_tokens
-  for i=1,#words do
-    for _, arg in ipairs(sh.internal.evaluate(words[i])) do
-      table.insert(ewords, arg)
-      has_tokens = has_tokens or arg:find("[<>]")
-    end
-  end
-  return table.remove(ewords, 1), ewords, has_tokens
-end
-
 function sh.internal.createThreads(commands, env, start_args)
   -- Piping data between programs works like so:
   -- program1 gets its output replaced with our custom stream.
@@ -241,18 +151,16 @@ function sh.internal.createThreads(commands, env, start_args)
   -- custom stream may have "redirect" entries for fallback/duplication.
   local threads = {}
   for i = 1, #commands do
-    local program, c_args, c_has_tokens = table.unpack(commands[i])
+    local command = commands[i]
+    local program, args, redirects = table.unpack(command)
     local name = tostring(program)
     local thread_env = type(program) == "string" and env or nil
-    local thread, reason = process.load(program, thread_env, function(...)
-      local cdata = process.info().data.command
-      local args, has_tokens, c_start_args = cdata.args, cdata.has_tokens, cdata.start_args
-      if has_tokens then
-        args = sh.internal.buildCommandRedirects(args)
+    local thread, reason = process.load(program or "/dev/null", thread_env, function(...)
+      if redirects then
+        sh.internal.openCommandRedirects(redirects)
       end
 
-      sh.internal.concatn(args, c_start_args)
-      sh.internal.concatn(args, {...}, select('#', ...))
+      args = tx.concat(args, start_args[i] or {}, table.pack(...))
 
       -- popen expects each process to first write an empty string
       -- this is required for proper thread order
@@ -260,22 +168,14 @@ function sh.internal.createThreads(commands, env, start_args)
       return table.unpack(args, 1, args.n or #args)
     end, name)
 
-    threads[i] = thread
-
     if not thread then
-      for i,t in ipairs(threads) do
+      for _,t in ipairs(threads) do
         process.internal.close(t)
       end
       return nil, reason
     end
 
-    local pdata = process.info(thread).data
-    pdata.command =
-    {
-      args = c_args,
-      has_tokens = c_has_tokens,
-      start_args = start_args and start_args[i] or {}
-    }
+    threads[i] = thread
 
   end
 
@@ -305,21 +205,61 @@ end
 
 function sh.internal.executePipes(pipe_parts, eargs, env)
   local commands = {}
-  for i=1,#pipe_parts do
-    commands[i] = table.pack(sh.internal.parseCommand(pipe_parts[i]))
-    if commands[i][1] == nil then
-      local err = commands[i][2]
-      if type(err) == "string" then
-        io.stderr:write(err,"\n")
+  for _,words in ipairs(pipe_parts) do
+    -- evaluated words
+    local ewords = {}
+    local has_globits
+    local has_redirects
+    for _,word in ipairs(words) do
+      local eword = {txt=""}
+      for _,part in ipairs(word) do
+        -- expand all parts if interpreted (not literal)
+        -- i.e '' is literal, "" and `` are interpreted
+        local next = part.txt
+        local quoted = part.qr
+        local literal, keep_whitespace, sub
+        if quoted then
+          literal = quoted[3]
+          keep_whitespace = quoted[1] == '"'
+          sub = quoted[1]:match('`') or next:find('`') and ''
+        else
+          if next:match("[%*%?]") then has_globits = true end
+          if next:match("[<>]") then has_redirects = true end
+        end
+        if not literal then
+          next = sh.expand(next)
+          if sub then
+            next = sh.internal.parse_sub(sub .. next .. sub)
+          end
+          if not keep_whitespace then
+            next = text.trim((next:gsub("%s+", " ")))
+          end
+        end
+        eword[#eword + 1] = { txt = next, qr = quoted }
+        eword.txt = eword.txt .. next
       end
-      return sh.internal.ec.parseCommand
+      ewords[#ewords + 1] = eword
     end
+    local redirects, reason
+    if has_redirects then
+      redirects, reason = sh.internal.buildCommandRedirects(ewords)
+      if reason then return false, reason end
+    end
+    local args = {}
+    for _,eword in ipairs(ewords) do
+      if has_globits then
+        for _,arg in ipairs(sh.internal.glob(eword)) do
+          args[#args + 1] = arg
+        end
+      else
+        args[#args + 1] = eword.txt
+      end
+    end
+    commands[#commands + 1] = table.pack(table.remove(args, 1), args, redirects)
   end
+
   local threads, reason = sh.internal.createThreads(commands, env, {[#commands]=eargs})  
-  if not threads then
-    io.stderr:write(reason,"\n")
-    return false
-  end
+  if not threads then return false, reason end
   return sh.internal.runThreads(threads)
 end
 
@@ -345,25 +285,11 @@ function sh.execute(env, command, ...)
   return sh.internal.execute_complex(statements, eargs, env)
 end
 
-function sh.internal.concatn(apack, bpack, bn)
-  local an = (apack.n or #apack)
-  bn = bn or bpack.n or #bpack
-  for i=1,bn do
-    apack[an + i] = bpack[i]
-  end
-  apack.n = an + bn
+function sh.hintHandler(full_line, cursor)
+  return sh.internal.hintHandlerImpl(full_line, cursor)
 end
 
-setmetatable(sh,
-{
-  __index = function(tbl, key)
-    setmetatable(sh.internal, nil)
-    setmetatable(sh, nil)
-    dofile("/opt/core/full_sh.lua")
-    return rawget(tbl, key)
-  end
-})
-
-setmetatable(sh.internal, getmetatable(sh))
+require("package").delay(sh, "/opt/core/full_sh.lua")
+require("package").delay(sh.internal, "/opt/core/full_sh.lua")
 
 return sh

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
@@ -183,7 +183,8 @@ function term.read(history, dobreak, hint, pwchar, filter)
   if not io.stdin.tty then
     return io.read()
   end
-  local handler = history or {}
+  history = history or {}
+  local handler = history
   handler.hint = handler.hint or hint
 
   local cursor = tty.internal.build_vertical_reader()

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/text.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/text.lua
@@ -1,13 +1,10 @@
 local unicode = require("unicode")
 local tx = require("transforms")
 
--- --[[@@]] are not just comments, but custom annotations for delayload methods.
--- See package.lua and the api wiki for more information
-
 local text = {}
 text.internal = {}
 
-text.syntax = {"^%d?>>?&%d+$",";","&&","||?","^%d?>>?",">>?","<"}
+text.syntax = {"^%d?>>?&%d+$","^%d?>>?",">>?","<%&%d+","<",";","&&","||?"}
 
 function text.trim(value) -- from http://lua-users.org/wiki/StringTrim
   local from = string.match(value, "^%s*()")
@@ -147,16 +144,7 @@ function text.internal.words(input, options)
   return tokens
 end
 
-setmetatable(text,
-{
-  __index = function(tbl, key)
-    setmetatable(text.internal, nil)
-    setmetatable(text, nil)
-    dofile("/opt/core/full_text.lua")
-    return rawget(tbl, key)
-  end
-})
-
-setmetatable(text.internal, getmetatable(text))
+require("package").delay(text, "/opt/core/full_text.lua")
+require("package").delay(text.internal, "/opt/core/full_text.lua")
 
 return text

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/thread.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/thread.lua
@@ -1,0 +1,206 @@
+local pipes = require("pipes")
+local event = require("event")
+local process = require("process")
+local computer = require("computer")
+
+local thread = {}
+
+local function waitForNumber(threads, n, timeout)
+  checkArg(1, threads, "table")
+  checkArg(2, n, "number")
+  checkArg(3, timeout, "number", "nil")
+  timeout = timeout or math.huge
+  local deadline = computer.uptime() + timeout
+  while deadline > computer.uptime() do
+    local num_dead = 0
+    for _,t in ipairs(threads) do
+      local result = t.process and t.process.data.result
+      local proc_ok = type(result) ~= "table" or result[1]
+      if t:status() ~= "running" -- suspended is considered dead to exit
+        or not proc_ok then -- the thread is killed if its attached process has a non zero exit
+        t:kill()
+        num_dead = num_dead + 1
+      end
+    end
+    if num_dead >= n then
+      return true
+    end
+    -- resume each non dead thread
+    -- we KNOW all threads are event.pull blocked
+    event.pull()
+  end
+  return nil, "thread join timed out"
+end
+
+function thread.waitForAny(threads, timeout)
+  return waitForNumber(threads, 1, timeout)
+end
+
+function thread.waitForAll(threads, timeout)
+  return waitForNumber(threads, #threads, timeout)
+end
+
+local box_thread = {}
+local box_thread_handle = {}
+box_thread_handle.close = thread.waitForAll
+
+local function get_box_thread_handle(handles, bCreate)
+  for _,next_handle in ipairs(handles) do
+    local btm_mt = getmetatable(next_handle)
+    if btm_mt and btm_mt.__index == box_thread_handle then
+      return next_handle
+    end
+  end
+  if bCreate then
+    local btm = setmetatable({}, {__index = box_thread_handle})
+    table.insert(handles, btm)
+    return btm
+  end
+end
+
+function box_thread:resume()
+  if self:status() ~= "suspended" then
+    return nil, "cannot resume " .. self:status() .. " thread"
+  end
+  getmetatable(self).__status = "running"
+end
+
+function box_thread:suspend()
+  if self:status() ~= "running" then
+    return nil, "cannot suspend " .. self:status() .. " thread"
+  end
+  getmetatable(self).__status = "suspended"
+end
+
+function box_thread:status()
+  return getmetatable(self).__status
+end
+
+function box_thread:join(timeout)
+  self:detach()
+  return box_thread_handle.close({self}, timeout)
+end
+
+function box_thread:kill()
+  self:detach()
+  if self:status() == "dead" then
+    return
+  end
+  getmetatable(self).__status = "dead"
+  self.pco.stack = {}
+end
+
+function box_thread:detach()
+  if not self.process then
+    return
+  end
+  local handles = self.process.data.handles
+  local btHandle = get_box_thread_handle(handles)
+  if not btHandle then
+    return nil, "thread failed to detach, process had no thread handle"
+  end
+  for i,h in ipairs(btHandle) do
+    if h == self then
+      return table.remove(btHandle, i)
+    end
+  end
+  return nil, "thread not found in parent process"
+end
+
+function box_thread:attach(parent)
+  checkArg(1, parent, "thread", "number", "nil")
+  local proc = process.info(parent)
+  if not proc then return nil, "thread failed to attach, process not found" end
+  self:detach()
+  -- attach to parent or the current process
+  self.process = proc
+  local handles = self.process.data.handles
+
+  -- this process may not have a box_thread manager handle
+  local btHandle = get_box_thread_handle(handles, true)
+  table.insert(btHandle, self)
+  return true
+end
+
+function thread.create(fp, ...)
+  checkArg(1, fp, "function")
+
+  local t = setmetatable({}, {__status="suspended",__index=box_thread})
+  t.pco = pipes.createCoroutineStack(function(...)
+    local mt = getmetatable(t)
+    mt.__status = "running"
+    local fp_co = t.pco.create(fp)
+    -- run fp_co until dead
+    -- pullSignal will yield_all past this point
+    -- but yield will return here, we pullSignal from here to yield_all
+    local args = table.pack(...)
+    while true do
+      local result = table.pack(t.pco.resume(fp_co, table.unpack(args, 1, args.n)))
+      if t.pco.status(fp_co) == "dead" then
+        break
+      end
+      args = table.pack(event.pull(table.unpack(result, 2, result.n)))
+    end
+    mt.__status = "dead"
+  end)
+  local handlers = event.handlers
+  local handlers_mt = getmetatable(handlers)
+  -- the event library sets a metatable on handlers
+  -- but not a pull field
+  if not handlers_mt.pull then
+    -- if we don't separate root handlers from thread handlers we see double dispatch
+    -- because the thread calls dispatch on pull as well
+    handlers_mt.handlers = {} -- root handlers
+    handlers_mt.pull = handlers_mt.__call -- the real computer.pullSignal
+    handlers_mt.current = function(field) return process.info().data[field] or handlers_mt[field] end
+    while true do
+      local key, value = next(handlers)
+      if not key then break end
+      handlers_mt.handlers[key] = value
+      handlers[key] = nil
+    end
+    handlers_mt.__index = function(_, key)
+      return handlers_mt.current("handlers")[key]
+    end
+    handlers_mt.__newindex = function(_, key, value)
+      handlers_mt.current("handlers")[key] = value
+    end
+    handlers_mt.__pairs = function(_, ...)
+      return pairs(handlers_mt.current("handlers"), ...)
+    end
+    handlers_mt.__call = function(tbl, ...)
+      return handlers_mt.current("pull")(tbl, ...)
+    end
+  end
+
+  local data = process.info(t.pco.stack[1]).data
+  data.handlers = {}
+  data.pull = function(_, timeout)
+    -- register a timeout handler
+    -- hack so that event.register sees the root handlers
+    local data_handlers = data.handlers
+    data.handlers = handlers_mt.handlers
+    event.register(
+      nil, -- nil key matches anything, timers use false keys
+      t.pco.resume_all,
+      timeout, -- wait for the time specified by the caller
+      1) -- we only want this thread to wake up once
+    data.handlers = data_handlers
+
+    -- yield_all will yield this pco stack
+    -- the callback will resume this stack
+    local event_data
+    repeat
+      event_data = table.pack(t.pco.yield_all(timeout))
+      -- during sleep, we may have been suspended
+    until getmetatable(t).__status ~= "suspended"
+    return table.unpack(event_data, 1, event_data.n)
+  end
+
+  t:attach()
+  t.pco.resume_all(...) -- threads start out running
+
+  return t
+end
+
+return thread

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/tools/programLocations.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/tools/programLocations.lua
@@ -1,4 +1,6 @@
 local computer = require("computer")
+local fs = require("filesystem")
+local shell = require("shell")
 local lib = {}
 
 function lib.locate(path)
@@ -11,6 +13,10 @@ end
 
 function lib.reportNotFound(path, reason)
   checkArg(1, path, "string")
+  if fs.isDirectory(shell.resolve(path)) then
+    io.stderr:write(path .. ": is a directory\n")
+    return 126
+  end
   local loot = lib.locate(path)
   if loot then
     io.stderr:write("The program '" .. path .. "' is currently not installed.  To install it:\n" ..
@@ -19,6 +25,7 @@ function lib.reportNotFound(path, reason)
   elseif type(reason) == "string" then
     io.stderr:write(path .. ": " .. reason .. "\n")
   end
+  return 127
 end
 
 return lib

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/transforms.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/transforms.lua
@@ -70,13 +70,6 @@ function lib.concat(...)
   return r
 end
 
-setmetatable(lib, 
-{
-  __index = function(tbl, key)
-    setmetatable(tbl, nil)
-    dofile("/opt/core/full_transforms.lua")
-    return rawget(tbl, key)
-  end
-})
+require("package").delay(lib, "/opt/core/full_transforms.lua")
 
 return lib

--- a/src/main/resources/assets/opencomputers/loot/openos/opt/core/boot.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/opt/core/boot.lua
@@ -1,7 +1,7 @@
 -- called from /init.lua
 local raw_loadfile = ...
 
-_G._OSVERSION = "OpenOS 1.6.3"
+_G._OSVERSION = "OpenOS 1.6.4"
 
 local component = component
 local computer = computer


### PR DESCRIPTION
the "thread" update

**Threads**
OpenOS 1.6.4 brings the new thread library api. Documentation in our ocdoc wiki soon to come. An openos thread is an autonomous non-blocking detachable child process
 * Autonomous: Threads asynchronously begin execution immediately after creation without needing to call resume. The thread proc may call coroutine.yield, but will resume on its own
 * Non-Blocking: Threads can call computer.pullSignal (or any higher level wrapper such as event.pull, io.pull, etc) without blocking the main kernel process nor any other thread
 * Detachable: By default, threads are scoped to the process in which they are created, i.e. their parent process. Any thread will block the parent process from closing unless:
  A. The thread detaches from the parent process. In which case it does not block any process and runs independently, e.g. `t:detach()`
  or
  B. The parent process throws an exception or calls os.exit in which case all attached threads are killed, e.g. `os.exit()`
  or
  C. The thread is manually suspended, e.g. `t:suspend()`

**Command Redirection**
The other major improvement in this update is highly improved shell parsing for command substitution and io redirection. Some highlights include
 * Can place before the command now, e.g. `2>/dev/null ./run_my_scripts.lua`
 * Can properly use globbing or env vars as redirect targets, e.g. `./run_my_scripts.lua >$my_log_file`
 * Fixed various bugs related to redirect and argument evaluation

**Memory**
50k free! As I love to do, this update reduces memory allocation needed to reach the shell prompt. The majority of the recent memory improvements are not just delaying allocation, but actual code cleanup and optimizations. Many of the changes are minor but they are numerous. With 1 stick of tier 1 RAM, openos reaches shell with 50k bytes free.

Changelog:
Bump version from 1.6.3 to 1.6.4
Cause grep to yield when taking too long
Remove additional gpu.bind calls during boot, reduces the number of screen resize calls
Move SHELL env var creation to /boot/94_shell.lua - This is an important user workflow fix to allow users to specify a custom SHELL without openos ever needing to load /bin/sh and its libraries
Fix event dispatch to not double call event timers in some scenarios
new /lib/thread.lua
fixed /lib/process from hiding exceptions in some scenarios
significant memory optimizations and code cleanup for /bin/sh
refactoring of command redirection, variable evaluation, glob expansion, and argument lists in /bin/sh
fixed term.setCursorBlink so that it properly waits for inf time for the next event when not blinking, rather than pulling every .5 seconds
fixed /bin/sh shell from losing exit_code when using || and && with multiple commands
fix /bin/lua error message when using os.exit
cherry picking serialization fix from 62471f7d320758bebb280666ed98388ea61cb4c8
fixed shebang support:  respect _ENV and removed hack in loadfile

Closes #2366 