### PR TITLE
Optimized filesystem.name() / Fix filesystem.copy()

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
@@ -283,7 +283,7 @@ end
 
 function filesystem.name(path)
   checkArg(1, path, "string")
-  return path:match("[^\\/]+$")
+  return path:match("([^\\/]+)[\\/]*$")
 end
 
 function filesystem.proxy(filter)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
@@ -282,8 +282,8 @@ function filesystem.path(path)
 end
 
 function filesystem.name(path)
-  local parts = segments(path)
-  return parts[#parts]
+  checkArg(1, path, "string")
+  return path:match("[^\\/]+$")
 end
 
 function filesystem.proxy(filter)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
@@ -436,7 +436,7 @@ function filesystem.rename(oldPath, newPath)
 end
 
 function filesystem.copy(fromPath, toPath)
-  local data
+  local data = false
   local input, reason = filesystem.open(fromPath, "rb")
   if input then
     local output, reason = filesystem.open(toPath, "wb")

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
@@ -283,7 +283,8 @@ end
 
 function filesystem.name(path)
   checkArg(1, path, "string")
-  return path:match("([^\\/]+)[\\/]*$")
+  local parts = segments(path)
+  return parts[#parts]
 end
 
 function filesystem.proxy(filter)


### PR DESCRIPTION
There is no need to split and run path parsing. Just grab the substring at the end.
Also added argument checking.