### PR TITLE
Optimized sleep.lua interval parsing

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/sleep.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/sleep.lua
@@ -39,7 +39,7 @@ end
 local total_time = 0
 
 for _,v in ipairs(args) do
-  local interval, time_type = v:match('^(%d+%.?%d*)([smhd]?)$')
+  local interval, time_type = v:match('^([%d%.]+)([smhd]?)$')
   interval = tonumber(interval)
 
   if not interval or interval < 0 then

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/sleep.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/sleep.lua
@@ -39,23 +39,15 @@ end
 local total_time = 0
 
 for _,v in ipairs(args) do
-  local interval = v:match('^%d+%.?%d*[smhd]?$')
-  if not interval then
-    help(v)
-    return 1
-  end
-
-  local time_type = interval:match('[smhd]') or ''
-  interval = interval:sub(1, -#time_type-1)
+  local interval, time_type = v:match('^(%d+%.?%d*)([smhd]?)$')
   interval = tonumber(interval)
 
-  if interval < 0 then
+  if not interval or interval < 0 then
     help(v)
     return 1
   end
 
-  interval = time_type_multiplier(time_type) * interval
-  total_time = total_time + interval
+  total_time = total_time + time_type_multiplier(time_type) * interval
 end
 
 os.sleep(total_time)


### PR DESCRIPTION
Modified regex to use captures, consolidated invalid interval checks.
Note: **tonumber(_nil_)** safely returns **_nil_**