### PR TITLE
Added 'quiet' mode to serialization.serialize()

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -70,7 +70,7 @@ local function loadConfig()
       if f then
         local serialization = require("serialization")
         for k, v in pairs(env) do
-          f:write(k.."="..tostring(serialization.serialize(v, math.huge)).."\n")
+          f:write(k.."="..tostring(serialization.serialize(v, nil, true)).."\n")
         end
         f:close()
       end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/rc.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/rc.lua
@@ -20,7 +20,7 @@ local function saveConfig(conf)
     return nil, reason
   end
   for key, value in pairs(conf) do
-    file:write(tostring(key) .. " = " .. require("serialization").serialize(value) .. "\n")
+    file:write(tostring(key) .. " = " .. require("serialization").serialize(value, nil, true) .. "\n")
   end
   
   file:close()

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/serialization.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/serialization.lua
@@ -8,7 +8,7 @@ end
 
 -- Important: pretty formatting will allow presenting non-serializable values
 -- but may generate output that cannot be unserialized back.
-function serialization.serialize(value, pretty)
+function serialization.serialize(value, pretty, quiet)
   local kw =  {["and"]=true, ["break"]=true, ["do"]=true, ["else"]=true,
                ["elseif"]=true, ["end"]=true, ["false"]=true, ["for"]=true,
                ["function"]=true, ["goto"]=true, ["if"]=true, ["in"]=true,
@@ -41,6 +41,8 @@ function serialization.serialize(value, pretty)
       if ts[v] then
         if pretty then
           return "recursion"
+        elseif quiet then
+          return "nil --[[ unsupported recursion ]]"
         else
           error("tables with cycles are not supported")
         end
@@ -104,13 +106,15 @@ function serialization.serialize(value, pretty)
     else
       if pretty then
         return tostring(v)
+      eseif quiet then
+        return "nil --[[ unsupported type '" .. t .. "' ]]"
       else
         error("unsupported type: " .. t)
       end
     end
   end
   local result = s(value, 1)
-  local limit = type(pretty) == "number" and pretty or 10
+  local limit = pretty and (tonumber(pretty) or 10) or math.huge
   if pretty then
     local truncate = 0
     while limit > 0 and truncate do


### PR DESCRIPTION
'quiet' suppresses errors and writes nil plus a commented reason to any unsupported values.
This change also implements a fix allowing limitless serialization with 'pretty' off.
This is the new default action. Setting 'pretty' to true preserves the default limit to 10 lines.