### PR TITLE
Better scrollwheel handling in edit.lua

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -630,7 +630,7 @@ local function onScroll(direction)
     scrollY = sy
 
     term.setCursorBlink(false)
-    gpu.copy(x, math.max(y, y + dy), w, h - math.abs(dy), 0, -dy)
+    if math.abs(dy) < h then gpu.copy(x, math.max(y, y + dy), w, h - math.abs(dy), 0, -dy) end
     for py = 1, math.min(-dy, h) do
       gpu.set(x, y + py - 1, unicode.wtrunc(text.padRight(removePrefix(buffer[py + sy] or "", scrollX), w), w))
     end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -621,8 +621,12 @@ local function onClick(x, y)
 end
 
 local function onScroll(direction)
-  local cbx, cby = getCursor()
-  setCursor(cbx, cby - direction * 12)
+  local _, _, _, h = getArea()
+  local x, y = getCursor()
+
+--  TODO: Implement a dedicated scrolling/redraw function
+  setCursor(x, scrollY + (direction>0 and 0 or h+1))
+  setCursor(x, math.max(math.min(y, scrollY + h), scrollY + 1))
 end
 
 -------------------------------------------------------------------------------

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -626,7 +626,7 @@ local function onScroll(direction)
 
   if sy ~= scrollY then
     local cx, cy = getCursor()
-    local dy = sy - scrollY;
+    local dy = sy - scrollY
     scrollY = sy
 
     term.setCursorBlink(false)


### PR DESCRIPTION
Now scrolls the screen up/down instead of jumping the cursor a bunch of lines.
This tries to preserve cursor position if it's still on screen.