### PR TITLE
Fix wtrunc behaviour with missing glyphs

### DIFF
--- a/src/main/scala/li/cil/oc/server/machine/luac/UnicodeAPI.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luac/UnicodeAPI.scala
@@ -81,7 +81,7 @@ class UnicodeAPI(owner: NativeLuaArchitecture) extends NativeLuaAPI(owner) {
       var width = 0
       var end = 0
       while (width < count) {
-        width += FontUtils.wcwidth(value(end))
+        width += math.max(1, FontUtils.wcwidth(value(end)))
         end += 1
       }
       if (end > 1) lua.pushString(value.substring(0, end - 1))

--- a/src/main/scala/li/cil/oc/server/machine/luaj/UnicodeAPI.scala
+++ b/src/main/scala/li/cil/oc/server/machine/luaj/UnicodeAPI.scala
@@ -53,7 +53,7 @@ class UnicodeAPI(owner: LuaJLuaArchitecture) extends LuaJAPI(owner) {
       var width = 0
       var end = 0
       while (width < count) {
-        width += FontUtils.wcwidth(value(end))
+        width += math.max(1, FontUtils.wcwidth(value(end)))
         end += 1
       }
       if (end > 1) LuaValue.valueOf(value.substring(0, end - 1))


### PR DESCRIPTION
This PR makes `unicode.wtrunc` treat missing glyphs as having a width of 1 like `unicode.wlen` does, which should fix some OpenOS issues related to the usage of both functions.

@payonel

Closes #2384
Closes #2454