### PR TITLE
Correct name for Galacticraft item

### DIFF
--- a/src/main/resources/assets/opencomputers/recipes/default.recipes
+++ b/src/main/resources/assets/opencomputers/recipes/default.recipes
@@ -216,7 +216,7 @@ abstractbuscard {
           ["", "oc:materialCard", ""]]
 }
 worldsensorcard {
-  input: [[{item="GalacticraftCore:item.sensorLens"}, "oc:circuitChip2", ""]
+  input: [[{item="galacticraftcore:sensor_lens"}, "oc:circuitChip2", ""]
           ["", "oc:materialCard", ""]]
 }
 


### PR DESCRIPTION
In the recipe for the World Sensor Card in OC Integration you're using an outdated (1.7.10) name for a Galacticraft item.

This is causing an error:
>
    [22:32:41] [Server thread/ERROR] [OpenComputers]: Failed adding recipe for 'worldSensorCard', you will not be able to craft this item.
    li.cil.oc.common.recipe.Recipes$RecipeException: No item found with name 'GalacticraftCore:item.sensorLens'.
        at li.cil.oc.common.recipe.Recipes$.parseIngredient(Recipes.scala:393) ~[Recipes$.class:?]
        at li.cil.oc.integration.vanilla.RecipeHandler$$anonfun$1$$anonfun$apply$1.apply(RecipeHandler.scala:25) ~[RecipeHandler$$anonfun$1$$anonfun$apply$1.class:?]

The correct item name is:

  1.10.2+   ```galacticraftcore:sensor_lens```

  1.8.9    ```GalacticraftCore:sensor_lens```

I wasn't sure which branch to make this PR to - I've made it to ```master-MC1.11``` but you might want to make the same change to any other branch from 1.8.9 which is still being maintained.

It's likely that we'll keep to ```galacticraftcore:sensor_lens``` going forward.