### PR TITLE
closes #2507

### DIFF
--- a/src/main/resources/assets/opencomputers/lua/machine.lua
+++ b/src/main/resources/assets/opencomputers/lua/machine.lua
@@ -577,7 +577,7 @@ do
     checkArg(3, repl, "number", "string", "function", "table")
     checkArg(4, n, "number", "nil")
 
-    if #s < SHORT_STRING or type(repl) == "function" then
+    if #s < SHORT_STRING then
       return string_gsub(s, pattern, repl, n)
     end
 


### PR DESCRIPTION
/bin/less and /bin/more are able to lock up the system if they call string.gsub(string, function) on a very large string (~144k chars long).
The machine layer intercepts expensive strings calls by checking the length of the string, but it does not intercept gsub calls when the replace action is a function

The fix is to intercept all long string actions, not just non-function replacement gsub calls