### PR TITLE
introduce screens to gpus in robot components

### DIFF
--- a/src/main/scala/li/cil/oc/common/tileentity/Robot.scala
+++ b/src/main/scala/li/cil/oc/common/tileentity/Robot.scala
@@ -575,6 +575,7 @@ class Robot extends traits.Computer with traits.PowerInformation with IFluidHand
         for (slot <- componentSlots) {
           getComponentInSlot(slot) match {
             case keyboard: api.internal.Keyboard => buffer.node.connect(keyboard.node)
+            case gpu: li.cil.oc.server.component.GraphicsCard => buffer.node.connect(gpu.node)
             case _ =>
           }
         }


### PR DESCRIPTION
GPUs have neighbor visibility, and screens have network visibility. But in a robot the gpu and screen are sibling components, with edges to the machine, but without edges to each other. Thus during load they are not connected to each other (regardless of load order). Robots already have a provision for this issue for connecting screens to keyboards and keyboards to screens, but lacked a custom screen->gpu connection. This code change simply adds that search and connects all screens to all gpus.

closes #2302