### PR TITLE
Filesystem checkHandle can now accept a table

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/FileSystem.scala
+++ b/src/main/scala/li/cil/oc/server/component/FileSystem.scala
@@ -245,6 +245,11 @@ class FileSystem(val fileSystem: IFileSystem, var label: Label, val host: Option
   def checkHandle(args: Arguments, index: Int) = {
     if (args.isInteger(index)) {
       args.checkInteger(index)
+    } else if (args.isTable(index)) {
+      args.checkTable(index).get("handle") match {
+        case handle: Number => handle.intValue()
+        case _ => throw new IOException("bad file descriptor")
+      }
     } else args.checkAny(index) match {
       case handle: HandleValue => handle.handle
       case _ => throw new IOException("bad file descriptor")


### PR DESCRIPTION
This change changes FIleSystem.checkHandle() to also check for a table parameter.

Previously, checkHandle was not "language safe" (or at least, not JSON-safe):

`open()` returns a `HandleValue` (which is a type not exposed by the oc-api jar)
`checkHandle()` checks for either a `integer`, or a `HandleValue` object

When calling through a custom architecture, `HandleValue `may or may not be preserved, as the underlying language, unless it can attach the original Java object, may not be able to represent the `HandleValue` class, and so convert it to a `table`, which `checkHandle()` did not check for.

As an example, in the architecture I am currently working on (oc-v8, a javascript architecture based on the V8 engine used by Chrome and node.js), all data is passed back and forth in JSON format, turning into nested `table`(s) (objects in JSON), stripping typing information beyond JSON primitives. I could work around this on my end by checking for an object that looks like it was once a `HandleValue` and returning `.value` instead, but I would prefer to avoid component-specific workarounds in my code if I can reasonably avoid doing so.