### PR TITLE
Implement issue #2654

### DIFF
--- a/src/main/scala/li/cil/oc/client/GuiHandler.scala
+++ b/src/main/scala/li/cil/oc/client/GuiHandler.scala
@@ -88,7 +88,7 @@ object GuiHandler extends CommonGuiHandler {
               item.Tablet.get(stack, player).components.collect {
                 case Some(buffer: api.internal.TextBuffer) => buffer
               }.headOption match {
-                case Some(buffer: api.internal.TextBuffer) => new gui.Screen(buffer, true, () => true, () => true)
+                case Some(buffer: api.internal.TextBuffer) => new gui.Screen(buffer, true, () => true, () => buffer.isRenderingEnabled)
                 case _ => null
               }
             }

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -303,6 +303,7 @@ class TabletWrapper(var stack: ItemStack, var player: EntityPlayer) extends Comp
       case buffer: api.internal.TextBuffer =>
         buffer.setMaximumColorDepth(api.internal.TextBuffer.ColorDepth.FourBit)
         buffer.setMaximumResolution(80, 25)
+        buffer.setPowerState(true)
       case _ =>
     }
   }

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -303,7 +303,6 @@ class TabletWrapper(var stack: ItemStack, var player: EntityPlayer) extends Comp
       case buffer: api.internal.TextBuffer =>
         buffer.setMaximumColorDepth(api.internal.TextBuffer.ColorDepth.FourBit)
         buffer.setMaximumResolution(80, 25)
-        buffer.setPowerState(true)
       case _ =>
     }
   }
@@ -419,6 +418,13 @@ class TabletWrapper(var stack: ItemStack, var player: EntityPlayer) extends Comp
       if (lastRunning != machine.isRunning) {
         lastRunning = machine.isRunning
         markDirty()
+
+        if (machine.isRunning) {
+          components collect {
+            case Some(buffer: api.internal.TextBuffer) =>
+              buffer.setPowerState(true)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This makes it so that calling `component.screen.turnOff` on a tablet does something. It also makes it so that tablets, on boot, will issue an automatic call equivilent to `turnOn` to compensate for the fact you can't pass a redstone signal to a tablet-attached screen.

Closes #2654.