### PR TITLE
[1.10.2] Make cable collision box closer to cable shape

### DIFF
--- a/src/main/scala/li/cil/oc/client/renderer/block/CableModel.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/block/CableModel.scala
@@ -5,7 +5,6 @@ import java.util.Collections
 
 import li.cil.oc.client.Textures
 import li.cil.oc.common.block
-import li.cil.oc.common.block.Cable
 import li.cil.oc.common.tileentity
 import li.cil.oc.integration.Mods
 import li.cil.oc.util.BlockPosition
@@ -40,7 +39,7 @@ class CableModel extends SmartBlockModelBase {
             val faces = mutable.ArrayBuffer.empty[BakedQuad]
 
             val color = Some(t.getColor)
-            val mask = Cable.neighbors(t.world, t.getPos)
+            val mask = block.Cable.neighbors(t.world, t.getPos)
             faces ++= bakeQuads(Middle, cableTexture, color)
             for (side <- EnumFacing.values) {
               val connected = (mask & (1 << side.getIndex)) != 0


### PR DESCRIPTION
1.10.2+ version of #2668 

I'm going to be honest, I haven't tested this beyond checking it compiles. My version of IntelliJ and Gradle seem to have various grievances against OpenComputers so I gave up fighting :). Any tips would be much appreciated.