### PR TITLE
Fix wrong Gradle version being used on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ notifications:
 env:
   global: TERM=dumb
 
-install: gradle setupCIWorkspace
-script: gradle build
+install: ./gradlew setupCIWorkspace
+script: ./gradlew build
 
 cache:
   directories:


### PR DESCRIPTION
Using the default Gradle install on Travis is dangerous, because a version upgrade on their end could break the build. It's already broken because the version of ForgeGradle the current script relies on [expects `ScalaCompileOptions.setUseAnt` to exist,](https://github.com/MinecraftForge/ForgeGradle/blob/af713354a8bfb7757e7ad952e0aaf0623c62b69f/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java#L1135) but it was [removed in Gradle 3.](https://docs.gradle.org/3.0/release-notes.html#ant-based-scala-compiler-has-been-removed) Travis uses 4.0.1 by default.

This patch reconfigures Travis to use the Gradle wrapper instead, which standardizes the version in use. This actually used to be the case, but it was an [undocumented change in an unrelated commit](https://github.com/MightyPirates/OpenComputers/commit/b156684cc635532a5eb3a8920634541b0498a331) quite some time ago.