### PR TITLE
Fix runClient and runServer Gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ repositories {
 configurations {
     provided
     embedded
-    compile.extendsFrom provided, embedded
+    compile.extendsFrom embedded
 }
 
 dependencies {
@@ -229,6 +229,9 @@ dependencies {
     testCompile "org.scalactic:scalactic_2.11:2.2.6"
     testCompile "org.scalatest:scalatest_2.11:2.2.6"
 }
+
+// Add the "provided" dependencies to the compile (but NOT runtime) classpath.
+sourceSets.main.compileClasspath += [configurations.provided]
 
 idea.module.scopes.PROVIDED.plus += [configurations.provided]
 // TODO Causes errors on Gradle 2 for me (No such property: allDependencies for class: java.io.File).


### PR DESCRIPTION
`compile` dependencies are placed on the runtime classpath by Gradle. Because the `compile` configuration is set to extend from the `provided` config, all of those dependencies are put on the runtime classpath as well. That might be okay, except the set of dependencies certainly don't make up a functional modpack, so you end up with Forge spitting up dependency problems before you can reach the menu.

In this patch, `provided` is instead made a separate configuration, and explicitly added to ONLY the compile classpath of the main sourceset. [This is what newer versions of ForgeGradle do,](https://github.com/MinecraftForge/ForgeGradle/blob/f49079dd11c037f74cc740285b2c5504fbf8a7f6/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java#L502-L515) and it's also what's being done by setting dependencies to IDEA's "Provided" scope in [the wiki's build instructions.](http://ocdoc.cil.li/tutorial:debug_1.7.10)

Resolves #2561 and resolves #2614.