### PR TITLE
Fixed #2313

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/DebugCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/DebugCard.scala
@@ -661,7 +661,19 @@ object DebugCard {
     @Callback(doc = """function(x:number, y:number, z:number):number -- Get the metadata of the block at the specified coordinates.""")
     def getMetadata(context: Context, args: Arguments): Array[AnyRef] = {
       checkAccess()
-      result(world.getBlockState(new BlockPos(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))))
+      val state = world.getBlockState(new BlockPos(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2)))
+      result(state.getBlock.getMetaFromState(state))
+    }
+
+    @Callback(doc = """function(x:number, y:number, z:number[, actualState:boolean=false]) - gets the block state for the block at the specified position, optionally getting additional display related data""")
+    def getBlockState(context: Context, args: Arguments): Array[AnyRef] = {
+      checkAccess()
+      val pos = new BlockPos(args.checkInteger(0), args.checkInteger(1), args.checkInteger(2))
+      var state = world.getBlockState(pos)
+      if (args.optBoolean(3, false)) {
+        state = state.getActualState(world, pos)
+      }
+      result(state)
     }
 
     @Callback(doc = """function(x:number, y:number, z:number):number -- Check whether the block at the specified coordinates is loaded.""")


### PR DESCRIPTION
Added getBlockState method to debug card world value (returns a string as my converter attempt failed)

The getMetadata method now returns the numeric metadata instead of a block state string.