### PR TITLE
Fix issue with drones not reclaiming chunkloader tickets

### DIFF
--- a/src/main/scala/li/cil/oc/common/event/ChunkloaderUpgradeHandler.scala
+++ b/src/main/scala/li/cil/oc/common/event/ChunkloaderUpgradeHandler.scala
@@ -45,8 +45,15 @@ object ChunkloaderUpgradeHandler extends LoadingCallback {
     // so if the save is because the game is being quit the tickets aren't
     // actually being cleared. This will *usually* not be a problem, but it
     // has room for improvement.
-    restoredTickets.values.foreach(ticket => try ForgeChunkManager.releaseTicket(ticket) catch {
-      case _: Throwable => // Ignored.
+    restoredTickets.values.foreach(ticket => {
+      try{
+        val data = ticket.getModData
+        OpenComputers.log.warn(s"A chunk loader ticket has been orphaned! Address: ${data.getString("address")}, position: (${data.getInteger("x")}, ${data.getInteger("z")}). Removing...")
+        ForgeChunkManager.releaseTicket(ticket)
+      }
+      catch {
+        case _: Throwable => // Ignored.
+      }
     })
     restoredTickets.clear()
   }
@@ -73,9 +80,6 @@ object ChunkloaderUpgradeHandler extends LoadingCallback {
     val robotChunks = (for (x <- -1 to 1; z <- -1 to 1) yield new ChunkCoordIntPair(centerChunk.chunkXPos + x, centerChunk.chunkZPos + z)).toSet
 
     loader.ticket.foreach(ticket => {
-      if (ticket.getType() == ForgeChunkManager.Type.ENTITY && ticket.getEntity() == null && loader.host.isInstanceOf[Entity])
-        ticket.bindEntity(loader.host.asInstanceOf[Entity])
-
       ticket.getChunkList.collect {
         case chunk: ChunkCoordIntPair if !robotChunks.contains(chunk) => ForgeChunkManager.unforceChunk(ticket, chunk)
       }

--- a/src/main/scala/li/cil/oc/server/component/UpgradeChunkloader.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeChunkloader.scala
@@ -68,7 +68,7 @@ class UpgradeChunkloader(val host: EnvironmentHost) extends prefab.ManagedEnviro
         OpenComputers.log.info(s"Reclaiming chunk loader ticket at (${host.xPosition()}, ${host.yPosition()}, ${host.zPosition()}) in dimension ${host.world().provider.dimensionId}.")
       }
       ticket = ChunkloaderUpgradeHandler.restoredTickets.remove(node.address).orElse(host match {
-        case context: Context if context.isRunning => Option(ForgeChunkManager.requestTicket(OpenComputers, host.world, if (host.isInstanceOf[Entity]) ForgeChunkManager.Type.ENTITY else ForgeChunkManager.Type.NORMAL))
+        case context: Context if context.isRunning => Option(ForgeChunkManager.requestTicket(OpenComputers, host.world, ForgeChunkManager.Type.NORMAL))
         case _ => None
       })
       ChunkloaderUpgradeHandler.updateLoadedChunk(this)
@@ -97,7 +97,7 @@ class UpgradeChunkloader(val host: EnvironmentHost) extends prefab.ManagedEnviro
 
   private def setActive(enabled: Boolean) = {
     if (enabled && ticket.isEmpty) {
-      ticket = Option(ForgeChunkManager.requestTicket(OpenComputers, host.world, if (host.isInstanceOf[Entity]) ForgeChunkManager.Type.ENTITY else ForgeChunkManager.Type.NORMAL))
+      ticket = Option(ForgeChunkManager.requestTicket(OpenComputers, host.world, ForgeChunkManager.Type.NORMAL))
       ChunkloaderUpgradeHandler.updateLoadedChunk(this)
     }
     else if (!enabled && ticket.isDefined) {


### PR DESCRIPTION
I requested drone tickets of ForgeChunkManager.Type.ENTITY before, which will actually load the entity's chunk before calling the ticket loading callback. This means that the drone will see an empty restoredTicket list when it sets up its components, so it will never reclaim its ticket and could end up unloading. This most notably caused issues with reclaiming tickets after server/game restarts. I also added a log message to print when a ticket goes unclaimed to help with this stuff in the future.