### PR TITLE
[1.10] Make cable block highlight hug the block

### DIFF
--- a/src/main/scala/li/cil/oc/client/renderer/HighlightRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/HighlightRenderer.scala
@@ -1,23 +1,14 @@
 package li.cil.oc.client.renderer
 
-import li.cil.oc.Constants
-import li.cil.oc.Settings
-import li.cil.oc.api
 import li.cil.oc.client.Textures
-import li.cil.oc.common
-import li.cil.oc.util.BlockPosition
 import li.cil.oc.util.ExtendedAABB._
 import li.cil.oc.util.ExtendedWorld._
-import li.cil.oc.util.RenderState
-import net.minecraft.client.Minecraft
-import net.minecraft.client.renderer.GlStateManager
-import net.minecraft.client.renderer.OpenGlHelper
-import net.minecraft.client.renderer.RenderGlobal
-import net.minecraft.client.renderer.Tessellator
+import li.cil.oc.util.{BlockPosition, RenderState}
+import li.cil.oc.{Constants, Settings, api, common}
+import net.minecraft.client.renderer._
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats
 import net.minecraft.util.EnumFacing
-import net.minecraft.util.math.RayTraceResult
-import net.minecraft.util.math.Vec3d
+import net.minecraft.util.math.{RayTraceResult, Vec3d}
 import net.minecraftforge.client.event.DrawBlockHighlightEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.opengl.GL11
@@ -118,7 +109,7 @@ object HighlightRenderer {
         GlStateManager.enableBlend()
         OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 1)
         GlStateManager.color(0, 0, 0, 0.4f)
-        GL11.glLineWidth(2)
+        GlStateManager.glLineWidth(2)
         GlStateManager.disableTexture2D()
         GlStateManager.depthMask(false)
 
@@ -126,9 +117,40 @@ object HighlightRenderer {
           val bounds = shape.bounds.rotateTowards(print.facing)
           RenderGlobal.func_189697_a(bounds.expand(expansion, expansion, expansion)
             .offset(blockPos.x, blockPos.y, blockPos.z)
-            .offset(-pos.xCoord, -pos.yCoord, -pos.zCoord), 0, 0, 0, 0x66/0xFFf.toFloat)
+            .offset(-pos.xCoord, -pos.yCoord, -pos.zCoord), 0, 0, 0, 0x66 / 0xFFf.toFloat)
         }
 
+        GlStateManager.depthMask(true)
+        GlStateManager.enableTexture2D()
+        GlStateManager.disableBlend()
+
+        e.setCanceled(true)
+      case cable: common.tileentity.Cable =>
+        // See RenderGlobal.drawSelectionBox.
+        GlStateManager.enableBlend()
+        OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 1)
+        GlStateManager.color(0, 0, 0, 0.4f)
+        GlStateManager.glLineWidth(2)
+        GlStateManager.disableTexture2D()
+        GlStateManager.depthMask(false)
+        GlStateManager.pushMatrix()
+
+        val player = e.getPlayer
+        GlStateManager.translate(
+          blockPos.x - (player.lastTickPosX + (player.posX - player.lastTickPosX) * e.getPartialTicks),
+          blockPos.y - (player.lastTickPosY + (player.posY - player.lastTickPosY) * e.getPartialTicks),
+          blockPos.z - (player.lastTickPosZ + (player.posZ - player.lastTickPosZ) * e.getPartialTicks)
+        )
+
+        val mask = common.block.Cable.neighbors(world, hitInfo.getBlockPos)
+        val tesselator = Tessellator.getInstance
+        val buffer = tesselator.getBuffer
+
+        buffer.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION)
+        Cable.drawOverlay(buffer, mask)
+        tesselator.draw()
+
+        GlStateManager.popMatrix()
         GlStateManager.depthMask(true)
         GlStateManager.enableTexture2D()
         GlStateManager.disableBlend()
@@ -137,4 +159,88 @@ object HighlightRenderer {
       case _ =>
     }
   }
+
+  private object Cable {
+    private final val EXPAND = 0.002f
+    private final val MIN = common.block.Cable.MIN - EXPAND
+    private final val MAX = common.block.Cable.MAX + EXPAND
+
+    def drawOverlay(buffer: VertexBuffer, mask: Int): Unit = {
+      // Draw the cable arms
+      for (side <- EnumFacing.values) {
+        if (((1 << side.getIndex) & mask) != 0) {
+          val offset = if (side.getAxisDirection == EnumFacing.AxisDirection.NEGATIVE) -EXPAND else 1 + EXPAND
+          val centre = if (side.getAxisDirection == EnumFacing.AxisDirection.NEGATIVE) MIN else MAX
+
+          // Draw the arm end quad
+          drawLineAdjacent(buffer, side.getAxis, offset, MIN, MIN, MIN, MAX)
+          drawLineAdjacent(buffer, side.getAxis, offset, MIN, MAX, MAX, MAX)
+          drawLineAdjacent(buffer, side.getAxis, offset, MAX, MAX, MAX, MIN)
+          drawLineAdjacent(buffer, side.getAxis, offset, MAX, MIN, MIN, MIN)
+
+          // Draw the connecting lines to the middle
+          drawLineAlong(buffer, side.getAxis, MIN, MIN, offset, centre)
+          drawLineAlong(buffer, side.getAxis, MAX, MIN, offset, centre)
+          drawLineAlong(buffer, side.getAxis, MAX, MAX, offset, centre)
+          drawLineAlong(buffer, side.getAxis, MIN, MAX, offset, centre)
+        }
+      }
+
+      // Draw the cable core
+      drawCore(buffer, mask, EnumFacing.WEST, EnumFacing.DOWN, EnumFacing.Axis.Z)
+      drawCore(buffer, mask, EnumFacing.WEST, EnumFacing.UP, EnumFacing.Axis.Z)
+      drawCore(buffer, mask, EnumFacing.EAST, EnumFacing.DOWN, EnumFacing.Axis.Z)
+      drawCore(buffer, mask, EnumFacing.EAST, EnumFacing.UP, EnumFacing.Axis.Z)
+
+      drawCore(buffer, mask, EnumFacing.WEST, EnumFacing.NORTH, EnumFacing.Axis.Y)
+      drawCore(buffer, mask, EnumFacing.WEST, EnumFacing.SOUTH, EnumFacing.Axis.Y)
+      drawCore(buffer, mask, EnumFacing.EAST, EnumFacing.NORTH, EnumFacing.Axis.Y)
+      drawCore(buffer, mask, EnumFacing.EAST, EnumFacing.SOUTH, EnumFacing.Axis.Y)
+
+      drawCore(buffer, mask, EnumFacing.DOWN, EnumFacing.NORTH, EnumFacing.Axis.X)
+      drawCore(buffer, mask, EnumFacing.DOWN, EnumFacing.SOUTH, EnumFacing.Axis.X)
+      drawCore(buffer, mask, EnumFacing.UP, EnumFacing.NORTH, EnumFacing.Axis.X)
+      drawCore(buffer, mask, EnumFacing.UP, EnumFacing.SOUTH, EnumFacing.Axis.X)
+    }
+
+    /** Draw part of the core object */
+    private def drawCore(buffer: VertexBuffer, mask: Int, a: EnumFacing, b: EnumFacing, other: EnumFacing.Axis): Unit = {
+      if (((mask >> a.ordinal) & 1) != ((mask >> b.ordinal) & 1)) return
+
+      val offA = if (a.getAxisDirection == EnumFacing.AxisDirection.NEGATIVE) MIN else MAX
+      val offB = if (b.getAxisDirection == EnumFacing.AxisDirection.NEGATIVE) MIN else MAX
+      drawLineAlong(buffer, other, offA, offB, MIN, MAX)
+    }
+
+    /** Draw a line parallel to an axis */
+    private def drawLineAlong(buffer: VertexBuffer, axis: EnumFacing.Axis, offA: Double, offB: Double, start: Double, end: Double): Unit = {
+      axis match {
+        case EnumFacing.Axis.X =>
+          buffer.pos(start, offA, offB).endVertex()
+          buffer.pos(end, offA, offB).endVertex()
+        case EnumFacing.Axis.Y =>
+          buffer.pos(offA, start, offB).endVertex()
+          buffer.pos(offA, end, offB).endVertex()
+        case EnumFacing.Axis.Z =>
+          buffer.pos(offA, offB, start).endVertex()
+          buffer.pos(offA, offB, end).endVertex()
+      }
+    }
+
+    /** Draw a line perpendicular to an axis */
+    private def drawLineAdjacent(buffer: VertexBuffer, axis: EnumFacing.Axis, offset: Double, startA: Double, startB: Double, endA: Double, endB: Double): Unit = {
+      axis match {
+        case EnumFacing.Axis.X =>
+          buffer.pos(offset, startA, startB).endVertex()
+          buffer.pos(offset, endA, endB).endVertex()
+        case EnumFacing.Axis.Y =>
+          buffer.pos(startA, offset, startB).endVertex()
+          buffer.pos(endA, offset, endB).endVertex()
+        case EnumFacing.Axis.Z =>
+          buffer.pos(startA, startB, offset).endVertex()
+          buffer.pos(endA, endB, offset).endVertex()
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
This allows you to reach behind a cable, as the highlight box taking up the whole block. I'm happy to add a 1.7.10 version, but I'd like to check that people are OK with how everything looks first. I'm also open to ways the code could be improved - I've tried to make the direction handling as generic as possible, but it's not perfect.

One thing I'm not entirely sure about is black notch on the end of cables. I've currently excluded it from the bounding box (as that is what was done before), but it may be better to include it.

### Screenshots
![A basic cable intersection](https://user-images.githubusercontent.com/4346137/36455094-8ed0e15a-1696-11e8-97fa-0f59474ab891.png "A basic cable intersection") ![A flat cable part](https://user-images.githubusercontent.com/4346137/36455107-99f529c4-1696-11e8-8fe5-6c3b46a630c7.png "A flat cable part") ![The cable 'core'](https://user-images.githubusercontent.com/4346137/36455099-94e7d922-1696-11e8-94bd-7a462486d41a.png "The cable 'core'")
