### PR TITLE
Proper .prop file recognition

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/install_basics.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/install_basics.lua
@@ -111,7 +111,7 @@ for dev, path in pairs(devices) do
       address ~= tmpAddress and
       not (address == rootfs.address and not rootfs.isReadOnly())) then
     local prop = {}
-    local prop_path = path .. "/.prop"
+    local prop_path = install_path .. "/.prop"
     local prop_file = fs.open(prop_path)
     if prop_file then
       local prop_data = prop_file:read(math.huge)


### PR DESCRIPTION
Install currently only checks .prop files at the root of a device instead of the actual path where the installation is coming from. This can cause issues specifically when using the --from option if it is targeted at anything other than the root of a filesystem. This minor change fixes that.