### PR TITLE
Fix Extracells & mekanism deps. Fixes #2855

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,7 @@ repositories {
     maven { url "http://tehnut.info/maven" }
 	maven { url "http://maven.thiakil.com" }
     maven { url "http://cc.crzd.me/maven/" }
-	ivy {
-        name 'ExtraCells'
-        artifactPattern "http://addons-origin.cursecdn.com/files/${config.extracells.cf}/[module]-[revision].[ext]"
-    }
+	maven { url "https://minecraft.curseforge.com/api/maven/" }
 }
 
 configurations {
@@ -101,9 +98,9 @@ dependencies {
 	provided ("appeng:appliedenergistics2:${config.ae2.version}:api") {
 		transitive = false
 	}
-	provided name: 'ExtraCells', version: config.extracells.version, ext: 'jar'
+	provided "extracells2:ExtraCells-api:${config.extracells.version}"
 	
-	provided (name: 'Mekanism', version: config.mekanism.version, classifier: 'api') {
+	provided("mekanism:Mekanism:${config.mekanism.version}:api") {
 		transitive = false
 	}
 

--- a/build.properties
+++ b/build.properties
@@ -9,13 +9,13 @@ mod.version=1.7.2
 ae2.version=rv5-stable-4
 cc.version=1.80pr1-build0
 extracells.cf=2500/596
-extracells.version=api-1.12.2-2.5.3a25
+extracells.version=1.12.2:2.5.3a25
 forestry.version=5.5.0.157
 hwyla.version=1.8.20-B35_1.12
 ic2.version=2.8.26-ex112
 jei.version=4.8.5.151
 mcmp.version=2.2.2_38
-mekanism.version=1.12.1-9.4.1.326
+mekanism.version=1.12.2-9.4.3.330
 tis3d.version=1.3.0.12
 
 maven.url=file:///home/www/maven.cil.li/web


### PR DESCRIPTION
ExtraCells: Curse returns a http 403 code on trying to load the ivy xml and completely bails now. Moved to using CF's maven endpoint. Dep string found via https://github.com/Wyn-Price/CurseForge-Maven-Helper

Mekanism: switched to a build that uses a `group`ed path, minor bump in build number, but nothing major changed.