### PR TITLE
Fixes lightning issues with ShaderMod

### DIFF
--- a/src/main/scala/li/cil/oc/client/renderer/tileentity/ScreenRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/tileentity/ScreenRenderer.scala
@@ -9,6 +9,7 @@ import li.cil.oc.integration.util.Wrench
 import li.cil.oc.util.RenderState
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.client.renderer.OpenGlHelper
 import net.minecraft.client.renderer.Tessellator
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats
@@ -61,6 +62,7 @@ object ScreenRenderer extends TileEntitySpecialRenderer[Screen] {
 
     RenderState.pushAttrib()
 
+    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 0xFF, 0xFF)
     RenderState.disableEntityLighting()
     RenderState.makeItBlend()
     GlStateManager.color(1, 1, 1, 1)


### PR DESCRIPTION
The added line fixes lightning issues with shaders. The monitors are barely readable without this line. There is one issue with this fix and that is that at night the monitors will have a reddish tint.
Below I will show some pictures from before and after the change:

Before day:
![2018-07-10_22 22 04](https://user-images.githubusercontent.com/20015650/42535491-bfc28400-848f-11e8-9a94-3dfcdf6dc61d.png)

Before night:
![2018-07-10_22 22 21](https://user-images.githubusercontent.com/20015650/42535504-cdcbe9ec-848f-11e8-9ef3-66abbdb86a32.png)

After day:
![2018-07-10_22 07 23](https://user-images.githubusercontent.com/20015650/42535199-07e5b62c-848f-11e8-93d6-a832247eb5bd.png)

After night:
![2018-07-10_22 07 39](https://user-images.githubusercontent.com/20015650/42535206-0cf14ff0-848f-11e8-8c6c-9c753803f7ba.png)
