### PR TITLE
Adding Cut/Uncut operations to OpenOS editor

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -59,7 +59,9 @@ local function loadConfig()
     save = {{"control", "s"}},
     close = {{"control", "w"}},
     find = {{"control", "f"}},
-    findnext = {{"control", "g"}, {"control", "n"}, {"f3"}}
+    findnext = {{"control", "g"}, {"control", "n"}, {"f3"}},
+    cut = {{"control", "k"}},
+    uncut = {{"control", "u"}}
   }
   -- Generate config file if it didn't exist.
   if not config then
@@ -87,6 +89,11 @@ local buffer = {}
 local scrollX, scrollY = 0, 0
 local config = loadConfig()
 
+local cutBuffer = {}
+-- cutting is true while we're in a cutting operation and set to false when cursor changes lines
+-- basically, whenever you change lines, the cutting operation ends, so the next time you cut a new buffer will be created
+local cutting = false
+
 local getKeyBindHandler -- forward declaration for refind()
 
 local function helpStatusText()
@@ -110,7 +117,9 @@ local function helpStatusText()
   end
   return prettifyKeybind("Save", "save") ..
          prettifyKeybind("Close", "close") ..
-         prettifyKeybind("Find", "find")
+         prettifyKeybind("Find", "find") ..
+         prettifyKeybind("Cut", "cut") ..
+         prettifyKeybind("Uncut", "uncut")
 end
 
 -------------------------------------------------------------------------------
@@ -240,7 +249,12 @@ local function setCursor(nbx, nby)
   term.setCursor(nbx - scrollX, nby - scrollY)
   --update with term lib
   nbx, nby = getCursor()
-  gpu.set(x + w - 10, y + h, text.padLeft(string.format("%d,%d", nby, nbx), 10))
+  local locstring = string.format("%d,%d", nby, nbx)
+  if #cutBuffer > 0 then
+    locstring = string.format("(#%d) %s", #cutBuffer, locstring)
+  end
+  locstring = text.padLeft(locstring, 10)
+  gpu.set(x + w - #locstring, y + h, locstring)
 end
 
 local function highlight(bx, by, length, enabled)
@@ -316,6 +330,7 @@ local function up(n)
   if cby > 1 then
     setCursor(cbx, cby - n)
   end
+  cutting = false
 end
 
 local function down(n)
@@ -324,6 +339,7 @@ local function down(n)
   if cby < #buffer then
     setCursor(cbx, cby + n)
   end
+  cutting = false
 end
 
 local function delete(fullRow)
@@ -399,6 +415,7 @@ local function enter()
   end
   setCursor(1, cby + 1)
   setStatus(helpStatusText())
+  cutting = false
 end
 
 local findText = ""
@@ -452,6 +469,25 @@ local function find()
   end
   setCursor(cbx, cby)
   setStatus(helpStatusText())
+end
+
+local function cut()
+  if not cutting then
+    cutBuffer = {}
+  end
+  local cbx, cby = getCursor()
+  table.insert(cutBuffer, buffer[cby])
+  delete(true)
+  cutting = true
+  home()
+end
+
+local function uncut()
+  home()
+  for _, line in ipairs(cutBuffer) do
+    insert(line)
+    enter()
+  end 
 end
 
 -------------------------------------------------------------------------------
@@ -544,7 +580,9 @@ local keyBindHandlers = {
     findText = ""
     find()
   end,
-  findnext = find
+  findnext = find,
+  cut = cut,
+  uncut = uncut
 }
 
 getKeyBindHandler = function(code)


### PR DESCRIPTION
This patch adds a simple cut buffer to the editor, allowing you to cut whole lines to the buffer, and paste them out elsewhere. This feature was inspired by a similar feature in GNU nano (see [The Cutbuffer](https://www.nano-editor.org/dist/v2.9/nano.html#Editor-Basics)). It's not a full fledged clipboard, but provides simple, line-based cut and paste. A savvy user can get quite a lot of use out of this tool, as it makes removing, duplicating, and rearranging blocks of code much easier.

The basic operation is as follows:

- Pressing Control-K removes the current line and puts it in the cut buffer. Multiple consecutive lines can be copied this way. Moving the cursor to a new line ends the cut, meaning the next cut will start a new buffer.
- Pressing Control-U inserts the lines in the cut buffer before the current line. This doesn't clear the cut buffer, so the user can cut a line (or lines), and then uncut it many times.
- The cut buffer does not interact with the user's clipboard. It is a separate buffer. The cut buffer does not persist if edit is closed.
- The number of lines in the cut buffer is displayed next to the cursor position.

One problem I noticed is that if the user's `/etc/edit.cfg` file does not contain a binding for the new actions, they do not appear and are unusable. Simply deleting the config file so it can be regenerated fixes this, but it may not be obvious to users after an update. It may be worthwhile to use the default bindings when they are not present in the config file, but I considered that outside the scope of this patch.