### PR TITLE
Improved chunkloader upgrade

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1563,4 +1563,31 @@ opencomputers {
     # the native C locale).
     disableLocaleChanging: false
   }
+
+  # Chunkloader Upgrade settings.
+  chunkloader {
+    # If `true`, the chunkloader only loads chunks if its owner is online.
+    # If the owner goes offline, the chunks the upgrade kept loaded are unloaded;
+    # the upgrade keeps consuming energy, though, and `isActive()` returns `true`.
+    requireOnline: false
+
+    # If `true`, tickets are assigned to the player who owns the chunkloader rather
+    # than the mod, so the `forgeChunkLoading.cfg`'s limits get applied for that
+    # player. Makes it impossible to activate a chunkloader not owned by a player.
+    playerTickets: false
+
+    # This is a list of blacklisted dimensions. Chunkloaders may only be activated
+    # in dimensions that aren't present in this list.
+    dimBlacklist: []
+
+    # This is a list of whitelisted dimensions. Chunkloaders may only be activated
+    # in dimensions that are present in this list. If this list is empty,
+    # chunkloaders may be activated to all dimensions not blacklisted. Note that the
+    # blacklist is always applied, so if an entry is present in both the
+    # whitelist and the blacklist, the blacklist will win.
+    dimWhitelist: []
+
+    # Controls the level of logging: (`0` for quiet; `1` for more verbose; `2` for debug).
+    logLevel: 0
+  }
 }

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -410,6 +410,13 @@ class Settings(val config: Config) {
   val printsHaveOpacity = config.getBoolean("printer.printsHaveOpacity")
   val noclipMultiplier = config.getDouble("printer.noclipMultiplier") max 0
 
+  // chunkloader
+  val chunkloaderRequireOnline = config.getBoolean("chunkloader.requireOnline")
+  val chunkloaderPlayerTickets = config.getBoolean("chunkloader.playerTickets")
+  val chunkloaderDimBlacklist = config.getIntList("chunkloader.dimBlacklist")
+  val chunkloaderDimWhitelist = config.getIntList("chunkloader.dimWhitelist")
+  val chunkloaderLogLevel = config.getInt("chunkloader.logLevel") max 0
+
   // ----------------------------------------------------------------------- //
   // integration
   val modBlacklist = config.getStringList("integration.modBlacklist")

--- a/src/main/scala/li/cil/oc/common/event/ChunkloaderUpgradeHandler.scala
+++ b/src/main/scala/li/cil/oc/common/event/ChunkloaderUpgradeHandler.scala
@@ -2,36 +2,66 @@ package li.cil.oc.common.event
 
 import java.util
 
-import cpw.mods.fml.common.eventhandler.SubscribeEvent
-import li.cil.oc.OpenComputers
+import cpw.mods.fml.common.eventhandler.{EventPriority, SubscribeEvent}
+import li.cil.oc.util.ChunkloaderTicket
+import li.cil.oc.{OpenComputers, Settings}
 import li.cil.oc.api.event.RobotMoveEvent
 import li.cil.oc.server.component.UpgradeChunkloader
-import li.cil.oc.util.BlockPosition
-import net.minecraft.world.ChunkCoordIntPair
 import net.minecraft.world.World
 import net.minecraftforge.common.ForgeChunkManager
-import net.minecraftforge.common.ForgeChunkManager.LoadingCallback
-import net.minecraftforge.common.ForgeChunkManager.Ticket
-import net.minecraftforge.event.world.WorldEvent
-import net.minecraft.entity.Entity
+import net.minecraftforge.common.ForgeChunkManager.OrderedLoadingCallback
+import net.minecraftforge.common.ForgeChunkManager.PlayerOrderedLoadingCallback
+import net.minecraftforge.event.world.{ChunkEvent, WorldEvent}
+import com.google.common.collect.ListMultimap
+import com.google.common.collect.ArrayListMultimap
+import cpw.mods.fml.common.gameevent.PlayerEvent
+import net.minecraft.server.MinecraftServer
 
 import scala.collection.convert.WrapAsScala._
 import scala.collection.mutable
 
-object ChunkloaderUpgradeHandler extends LoadingCallback {
-  val restoredTickets = mutable.Map.empty[String, Ticket]
+object ChunkloaderUpgradeHandler extends OrderedLoadingCallback with PlayerOrderedLoadingCallback {
+  val chunkloaders = mutable.Set.empty[UpgradeChunkloader]
+  val restoredTickets = mutable.Map.empty[String, ChunkloaderTicket]
 
-  override def ticketsLoaded(tickets: util.List[Ticket], world: World) {
-    for (ticket <- tickets) {
-      val data = ticket.getModData
-      val address = data.getString("address")
-      restoredTickets += address -> ticket
-      if (data.hasKey("x") && data.hasKey("z")) {
-        val x = data.getInteger("x")
-        val z = data.getInteger("z")
-        OpenComputers.log.info(s"Restoring chunk loader ticket for upgrade at chunk ($x, $z) with address $address.")
+  override def playerTicketsLoaded(tickets: ListMultimap[String, ForgeChunkManager.Ticket], world: World) = {
+    val loaded: ListMultimap[String, ForgeChunkManager.Ticket] = ArrayListMultimap.create()
+    if (UpgradeChunkloader.playerTickets && UpgradeChunkloader.allowedDim(world.provider.dimensionId)) {
+      for (e <- tickets.entries) {
+        val ticket = e.getValue
+        if (isValidTicket(ticket)) {
+          loaded.put(ticket.getPlayerName, ticket)
+        }
+      }
+    }
+    loaded
+  }
 
-        ForgeChunkManager.forceChunk(ticket, new ChunkCoordIntPair(x, z))
+  override def ticketsLoaded(tickets: util.List[ForgeChunkManager.Ticket], world: World, maxTicketCount: Int) = {
+    val loaded = new util.ArrayList[ForgeChunkManager.Ticket]
+    if (!UpgradeChunkloader.playerTickets && UpgradeChunkloader.allowedDim(world.provider.dimensionId)) {
+      for (ticket <- tickets) {
+        if (isValidTicket(ticket)) {
+          loaded.add(ticket)
+        }
+      }
+    }
+    loaded
+  }
+
+  private def isValidTicket(ticket: ForgeChunkManager.Ticket) = {
+    val data = ticket.getModData
+    // omit malformed tickets
+    data.hasKey("x") && data.hasKey("y") && data.hasKey("z") && data.hasKey("address")
+  }
+
+  override def ticketsLoaded(tickets: util.List[ForgeChunkManager.Ticket], world: World) {
+    for (fcmTicket <- tickets) {
+      val ticket = new ChunkloaderTicket(fcmTicket)
+      restoredTickets += ticket.address -> ticket
+      OpenComputers.log.info(s"[chunkloader] Restoring: $ticket")
+      if (UpgradeChunkloader.canBeAwakened(ticket)) {
+        forceTicketChunks(ticket)
       }
     }
   }
@@ -46,18 +76,14 @@ object ChunkloaderUpgradeHandler extends LoadingCallback {
     // actually being cleared. This will *usually* not be a problem, but it
     // has room for improvement.
     restoredTickets.values.foreach(ticket => {
-      try{
-        val data = ticket.getModData
-        OpenComputers.log.warn(s"A chunk loader ticket has been orphaned! Address: ${data.getString("address")}, position: (${data.getInteger("x")}, ${data.getInteger("z")}). Removing...")
-        ForgeChunkManager.releaseTicket(ticket)
-      }
-      catch {
-        case _: Throwable => // Ignored.
+      if (ticket.unchecked) {
+        OpenComputers.log.warn(s"[chunkloader] Removing orphaned: $ticket")
+        ticket.release()
+        restoredTickets -= ticket.address
       }
     })
-    restoredTickets.clear()
   }
-
+  
   // Note: it might be necessary to use pre move to force load the target chunk
   // in case the robot moves across a chunk border into an otherwise unloaded
   // chunk (I think it would just fail to move otherwise).
@@ -69,28 +95,99 @@ object ChunkloaderUpgradeHandler extends LoadingCallback {
   def onMove(e: RobotMoveEvent.Post) {
     val machineNode = e.agent.machine.node
     machineNode.reachableNodes.foreach(_.host match {
-      case loader: UpgradeChunkloader => updateLoadedChunk(loader)
+      case loader: UpgradeChunkloader => loader.updateLoadedChunk()
       case _ =>
     })
   }
 
-  def updateLoadedChunk(loader: UpgradeChunkloader) {
-    val blockPos = BlockPosition(loader.host)
-    val centerChunk = new ChunkCoordIntPair(blockPos.x >> 4, blockPos.z >> 4)
-    val robotChunks = (for (x <- -1 to 1; z <- -1 to 1) yield new ChunkCoordIntPair(centerChunk.chunkXPos + x, centerChunk.chunkZPos + z)).toSet
+  object PersonalHandler {
+    val unloadedTickets = mutable.Map.empty[String, ChunkloaderTicket]
 
-    loader.ticket.foreach(ticket => {
-      ticket.getChunkList.collect {
-        case chunk: ChunkCoordIntPair if !robotChunks.contains(chunk) => ForgeChunkManager.unforceChunk(ticket, chunk)
-      }
+    @SubscribeEvent(priority = EventPriority.HIGHEST) // before UpgradeChunkloader.onDisconnect
+    def onChunkUnload(e: ChunkEvent.Unload) {
+      val chunkCoord = e.getChunk.getChunkCoordIntPair
+      val dim = e.getChunk.worldObj.provider.dimensionId
+      chunkloaders.foreach(loader => {
+        loader.ticket.foreach(ticket => if (ticket.dim == dim && ticket.chunkCoord == chunkCoord) {
+          restoredTickets += ticket.address -> ticket
+          if (Settings.get.chunkloaderLogLevel > 0)
+            OpenComputers.log.info(s"[chunkloader] Unloading: $loader")
+          loader.ticket = None // prevent release
+        })
+      })
+    }
 
-      for (chunk <- robotChunks) {
-        ForgeChunkManager.forceChunk(ticket, chunk)
-      }
+    @SubscribeEvent(priority = EventPriority.HIGH) // after ForgeChunkManager
+    def onWorldLoad(e: WorldEvent.Load) {
+      unloadedTickets.retain((_, ticket) => ticket.dim != e.world.provider.dimensionId)
+    }
 
-      ticket.getModData.setString("address", loader.node.address)
-      ticket.getModData.setInteger("x", centerChunk.chunkXPos)
-      ticket.getModData.setInteger("z", centerChunk.chunkZPos)
-    })
+    @SubscribeEvent(priority = EventPriority.HIGH) // after ForgeChunkManager, before UpgradeChunkloader.onDisconnect
+    def onWorldUnload(e: WorldEvent.Unload) {
+      val dim = e.world.provider.dimensionId
+      restoredTickets.values.foreach(ticket => if(ticket.dim == dim) {
+        OpenComputers.log.info(s"[chunkloader] Unloading: $ticket")
+        ticket.ownerName.foreach(ownerName => {
+          unloadedTickets += ticket.address -> ticket
+        })
+      })
+      restoredTickets.retain((_, ticket) => ticket.dim != dim)
+    }
+
+    @SubscribeEvent
+    def onPlayerLoggedIn(e: PlayerEvent.PlayerLoggedInEvent) {
+      // awake chunk loaders
+      chunkloaders.foreach(loader =>
+        loader.getOwnerName.foreach(ownerName => {
+          if (ownerName == e.player.getCommandSenderName) {
+            if (Settings.get.chunkloaderLogLevel > 0)
+              OpenComputers.log.info(s"[chunkloader] Awake: $loader")
+            loader.isSuspend = false
+            loader.updateLoadedChunk()
+          }
+        })
+      )
+      // force unloaded tickets
+      restoredTickets.values.foreach(ticket =>
+        ticket.ownerName.foreach(ownerName => {
+          if (ownerName == e.player.getCommandSenderName) {
+            forceTicketChunks(ticket)
+          }
+        })
+      )
+      // load unloaded dimensions
+      val unloadedDims = mutable.Set.empty[Int]
+      unloadedTickets.values.foreach(ticket => {
+        ticket.ownerName.foreach(ownerName => if (ownerName == e.player.getCommandSenderName) {
+          unloadedDims += ticket.dim
+        })
+      })
+      unloadedDims.foreach(dim => {
+        val world = MinecraftServer.getServer.worldServerForDimension(dim)
+        if (world == null) {
+          OpenComputers.log.warn(s"[chunkloader] Could not load dimension $dim")
+        }
+      })
+    }
+
+    @SubscribeEvent
+    def onPlayerLoggedOut(e: PlayerEvent.PlayerLoggedOutEvent) {
+      // suspend chunk loaders
+      chunkloaders.foreach(loader =>
+        loader.getOwnerName.foreach(ownerName => if (ownerName == e.player.getCommandSenderName) {
+          if (Settings.get.chunkloaderLogLevel > 0)
+            OpenComputers.log.info(s"[chunkloader] Suspend: $loader")
+          loader.isSuspend = true
+          loader.updateLoadedChunk()
+        })
+      )
+    }
+  }
+
+  def forceTicketChunks(ticket: ChunkloaderTicket) {
+    if (Settings.get.chunkloaderLogLevel > 1)
+      OpenComputers.log.info(s"[chunkloader] Force: $ticket")
+    ticket.unchecked = true
+    UpgradeChunkloader.chunks(ticket.chunkCoord).foreach(chunkCoord => ticket.forceChunk(chunkCoord))
   }
 }

--- a/src/main/scala/li/cil/oc/common/tileentity/Microcontroller.scala
+++ b/src/main/scala/li/cil/oc/common/tileentity/Microcontroller.scala
@@ -168,12 +168,12 @@ class Microcontroller extends traits.PowerAcceptor with traits.Hub with traits.C
     if (node == plug.node) {
       api.Network.joinNewNetwork(machine.node)
       machine.node.connect(snooperNode)
+      connectComponents()
     }
     if (plug.isPrimary)
       plug.node.connect(componentNodes(plug.side.ordinal()))
     else
       componentNodes(plug.side.ordinal).remove()
-    connectComponents()
   }
 
   override protected def onPlugDisconnect(plug: Plug, node: Node) {
@@ -182,6 +182,8 @@ class Microcontroller extends traits.PowerAcceptor with traits.Hub with traits.C
       plug.node.connect(componentNodes(plug.side.ordinal()))
     else
       componentNodes(plug.side.ordinal).remove()
+    if (node == plug.node)
+      disconnectComponents()
   }
 
   override protected def onPlugMessage(plug: Plug, message: Message): Unit = {

--- a/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala
@@ -95,11 +95,17 @@ object ModOpenComputers extends ModProxy {
     FMLCommonHandler.instance.bus.register(NanomachinesHandler.Common)
     FMLCommonHandler.instance.bus.register(SimpleComponentTickHandler.Instance)
     FMLCommonHandler.instance.bus.register(Tablet)
+    if (Settings.get.chunkloaderRequireOnline) {
+      FMLCommonHandler.instance.bus.register(ChunkloaderUpgradeHandler.PersonalHandler)
+    }
 
     MinecraftForge.EVENT_BUS.register(Analyzer)
     MinecraftForge.EVENT_BUS.register(AngelUpgradeHandler)
     MinecraftForge.EVENT_BUS.register(BlockChangeHandler)
     MinecraftForge.EVENT_BUS.register(ChunkloaderUpgradeHandler)
+    if (Settings.get.chunkloaderRequireOnline) {
+      MinecraftForge.EVENT_BUS.register(ChunkloaderUpgradeHandler.PersonalHandler)
+    }
     MinecraftForge.EVENT_BUS.register(EventHandler)
     MinecraftForge.EVENT_BUS.register(ExperienceUpgradeHandler)
     MinecraftForge.EVENT_BUS.register(FileSystemAccessHandler)
@@ -215,7 +221,6 @@ object ModOpenComputers extends ModProxy {
       Constants.ItemName.BatteryUpgradeTier1,
       Constants.ItemName.BatteryUpgradeTier2,
       Constants.ItemName.BatteryUpgradeTier3,
-      Constants.ItemName.ChunkloaderUpgrade,
       Constants.ItemName.CraftingUpgrade,
       Constants.ItemName.ExperienceUpgrade,
       Constants.ItemName.GeneratorUpgrade,
@@ -255,7 +260,6 @@ object ModOpenComputers extends ModProxy {
       Constants.ItemName.GraphicsCardTier2,
       Constants.ItemName.GraphicsCardTier3,
       Constants.ItemName.AngelUpgrade,
-      Constants.ItemName.ChunkloaderUpgrade,
       Constants.ItemName.CraftingUpgrade,
       Constants.ItemName.DatabaseUpgradeTier1,
       Constants.ItemName.DatabaseUpgradeTier2,

--- a/src/main/scala/li/cil/oc/server/command/ChunkloaderListCommand.scala
+++ b/src/main/scala/li/cil/oc/server/command/ChunkloaderListCommand.scala
@@ -1,0 +1,56 @@
+package li.cil.oc.server.command
+
+import li.cil.oc.common.command.SimpleCommand
+import li.cil.oc.OpenComputers
+import li.cil.oc.common.event.ChunkloaderUpgradeHandler
+import net.minecraft.command.ICommandSender
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.util.ChatComponentText
+
+object ChunkloaderListCommand extends SimpleCommand("oc_chunkloaders") {
+  aliases += "oc_cl"
+
+  override def getCommandUsage(source: ICommandSender): String = name
+
+  override def processCommand(source: ICommandSender, command: Array[String]) {
+    source match {
+      case player: EntityPlayer =>
+        list((s: String) => { player.addChatMessage(new ChatComponentText(s)) })
+      case _ =>
+        list((s: String) => { OpenComputers.log.info(s"[chunkloader] $s") })
+    }
+  }
+
+  private def list(out: String => Unit) {
+    val cnt = ChunkloaderUpgradeHandler.chunkloaders.size
+    if (cnt > 0) {
+      out(s"Currently there are ${ChunkloaderUpgradeHandler.chunkloaders.size} registered chunkloaders:")
+      ChunkloaderUpgradeHandler.chunkloaders.foreach(loader => {
+        out(s"$loader")
+      })
+    } else {
+      out(s"There is no currently registered chunkloaders.")
+    }
+    if (ChunkloaderUpgradeHandler.restoredTickets.size > 0) {
+      out(s"Currently there are ${ChunkloaderUpgradeHandler.restoredTickets.size} tickets in unloaded chunks:")
+      ChunkloaderUpgradeHandler.restoredTickets.values.foreach(ticket => {
+        out(s"$ticket")
+      })
+    }
+    val unloadedTickets = ChunkloaderUpgradeHandler.PersonalHandler.unloadedTickets
+    if (unloadedTickets.size > 0) {
+      out(s"Currently there are ${unloadedTickets.size} tickets in unloaded dimensions:")
+      unloadedTickets.values.foreach(ticket => {
+        out(s"$ticket")
+      })
+    }
+  }
+
+  // OP levels for reference:
+  // 1 - Ops can bypass spawn protection.
+  // 2 - Ops can use /clear, /difficulty, /effect, /gamemode, /gamerule, /give, /summon, /setblock and /tp, and can edit command blocks.
+  // 3 - Ops can use /ban, /deop, /kick, and /op.
+  // 4 - Ops can use /stop.
+
+  override def getRequiredPermissionLevel = 1
+}

--- a/src/main/scala/li/cil/oc/server/command/CommandHandler.scala
+++ b/src/main/scala/li/cil/oc/server/command/CommandHandler.scala
@@ -12,5 +12,6 @@ object CommandHandler {
     e.registerServerCommand(SpawnComputerCommand)
     e.registerServerCommand(DebugWhitelistCommand)
     e.registerServerCommand(SendDebugMessageCommand)
+    e.registerServerCommand(ChunkloaderListCommand)
   }
 }

--- a/src/main/scala/li/cil/oc/util/ChunkloaderTicket.scala
+++ b/src/main/scala/li/cil/oc/util/ChunkloaderTicket.scala
@@ -1,0 +1,67 @@
+package li.cil.oc.util
+
+import li.cil.oc.{OpenComputers, Settings}
+import net.minecraft.util.ChunkCoordinates
+import net.minecraft.world.{ChunkCoordIntPair, World}
+import net.minecraftforge.common.ForgeChunkManager
+
+class ChunkloaderTicket(private val fcmTicket: ForgeChunkManager.Ticket) {
+  val data = fcmTicket.getModData
+  val address = data.getString("address")
+  val dim = fcmTicket.world.provider.dimensionId
+  var unchecked: Boolean = false
+  def ownerName = Option(fcmTicket.getPlayerName)
+  def chunkCoord = new ChunkCoordIntPair(blockCoord.posX >> 4, blockCoord.posZ >> 4)
+  def blockCoord = new ChunkCoordinates(data.getInteger("x"), data.getInteger("y"), data.getInteger("z"))
+  def blockCoord_=(coord: ChunkCoordinates) {
+    data.setInteger("x", coord.posX)
+    data.setInteger("y", coord.posY)
+    data.setInteger("z", coord.posZ)
+  }
+  def chunkList = fcmTicket.getChunkList
+
+  def forceChunk(chunkCoord: ChunkCoordIntPair) {
+    if (Settings.get.chunkloaderLogLevel > 1)
+      OpenComputers.log.info(s"[chunkloader] Force chunk $chunkCoord: $this")
+    ForgeChunkManager.forceChunk(fcmTicket, chunkCoord)
+  }
+
+  def unforceChunk(chunkCoord: ChunkCoordIntPair) {
+    if (Settings.get.chunkloaderLogLevel > 1)
+      OpenComputers.log.info(s"[chunkloader] Unforce chunk $chunkCoord: $this")
+    ForgeChunkManager.unforceChunk(fcmTicket, chunkCoord)
+  }
+
+  def release(): Unit = {
+    try ForgeChunkManager.releaseTicket(fcmTicket) catch {
+      case _: Throwable => // Ignored.
+    }
+  }
+
+  override def toString = {
+    val sAddress = s"$address"
+    val sCoord = s", $blockCoord$chunkCoord/$dim"
+    val sOwner = if (ownerName.isDefined) s", owned by ${ownerName.get}" else ""
+    s"ticket{$sAddress$sCoord$sOwner}"
+  }
+}
+
+object  ChunkloaderTicket {
+
+  def requestPlayerTicket(world: World, address: String, ownerName: String) = {
+    Option(ForgeChunkManager.requestPlayerTicket(OpenComputers, ownerName, world, ForgeChunkManager.Type.NORMAL))
+    .map(fcmTicket => {
+      fcmTicket.getModData.setString("address", address)
+      fcmTicket.getModData.setString("ownerName", ownerName)
+      new ChunkloaderTicket(fcmTicket)
+    })
+  }
+
+  def requestTicket(world: World, address: String) = {
+    Option(ForgeChunkManager.requestTicket(OpenComputers, world, ForgeChunkManager.Type.NORMAL))
+      .map(fcmTicket =>{
+        fcmTicket.getModData.setString("address", address)
+        new ChunkloaderTicket(fcmTicket)
+      })
+  }
+}


### PR DESCRIPTION
# Improved chunkloader upgrade
This PR adds a lot of features, most of which give server admins more control over the behavior of the chunkloader upgrade.
Namely:

- An option to disable a chunkloader if its owner goes offline.
- A whitelist and a blacklist of dimensions in which the update is allowed to load chunks.
  Closes #2768.
- An option to use the `forgeChunkLoading.cfg`'s settings to limit number of tickets per player.
- A command that lists all chunkloaders in the world (`/oc_cl`).
- More verbose logging (the logging level is configurable).
- If a chunkloader is duplicated in a way so that multiple items share the same address,
  only one of them is allowed to work at a time.
- In case a drone with the chunkloader upgrade is teleported to another dimension, it requests a new ticket.
- Allows adapters and microcontrollers to have the chunkloader upgrade.
  Closes #2499.

A new configuration group, `chunkloader`, is added with the following settings:

- `requireOnline`. If `true`, the chunkloader only loads chunks if its owner is online.
  If the owner goes offline, the chunks the upgrade kept loaded are unloaded;
  the upgrade keeps consuming energy, though, and `isActive()` returns `true`.
  If the option is enabled, tickets are registered for the player, not for the mod.
- `dimBlacklist`. The chunkloader does not load chunks in dimensions whose IDs are listed there.
- `dimWhitelist`. This setting is the opposite of `dimBlacklist`, and lists dimensions in which the chunkloader is allowed to work.
  Ignored if left empty (so the upgrade works in all dimensions not listed in the blacklist).
  If the same entry appears in both lists, the blacklist takes precedence.
  `setActive()` returns `false` if the chunkloader is blocked in that dimension.
- `playerTicket`. If `true`, tickets are assigned to the player who owns the chunkloader rather than the mod,
  so the `forgeChunkLoading.cfg`'s limits get applied for that player.
  Makes it impossible to activate a chunkloader not owned by a player.
- `logLevel`. Controls the level of logging: (`0` for quiet; `1` for more verbose; `2` for debug).

A new command, `/oc_chunkloaders` (`/oc_cl`), is added, which lists chunkloaders in the loaded chunks,
and inactive registered tickets, displaying the following information:

- the component address
- the chunkloader status
  - `inactive` (the chunkloader is inactive)
  - `active` (the chunkloader is enabled, and loads chunks)
  - `active/suspend` (the chunkloader is enabled, but doesn't load chunks)
- the block coordinates
- the chunk coordinates
- the dimension ID
- the owner
