### PR TITLE
Add "leashHolder" as a name

### DIFF
--- a/src/main/scala/li/cil/oc/common/asm/ClassTransformer.scala
+++ b/src/main/scala/li/cil/oc/common/asm/ClassTransformer.scala
@@ -21,7 +21,7 @@ object ObfNames {
   final val Class_RenderLiving = Array("net/minecraft/client/renderer/entity/RenderLiving")
   final val Class_TileEntity = Array("net/minecraft/tileentity/TileEntity")
   final val Field_leashNBTTag = Array("leashNBTTag", "field_110170_bx")
-  final val Field_leashedToEntity = Array("leashedToEntity", "field_110168_bw")
+  final val Field_leashedToEntity = Array("leashedToEntity", "leashHolder", "field_110168_bw")
   final val Method_recreateLeash = Array("recreateLeash", "func_110165_bF")
   final val Method_recreateLeashDesc = Array("()V")
   final val Method_renderLeash = Array("renderLeash", "func_110827_b")


### PR DESCRIPTION
`field_110168_bw` was remapped from `leashedToEntity` to `leashHolder` as of the 20170919 mappings. Add this name so that the dev environments of other mods that use these mappings will work without "There were errors running the class transformer" messages.