### PR TITLE
Make it possible to use an analyzer as a tablet upgrade for reading component IDs.

### DIFF
--- a/src/main/scala/li/cil/oc/common/init/Items.scala
+++ b/src/main/scala/li/cil/oc/common/init/Items.scala
@@ -284,6 +284,7 @@ object Items extends ItemAPI {
       Option(safeGetStack(Constants.ItemName.PistonUpgrade)),
       Option(safeGetStack(Constants.BlockName.Geolyzer)),
       Option(safeGetStack(Constants.ItemName.NavigationUpgrade)),
+      Option(safeGetStack(Constants.ItemName.Analyzer)),
 
       Option(safeGetStack(Constants.ItemName.GraphicsCardTier2)),
       Option(safeGetStack(Constants.ItemName.RedstoneCardTier2)),

--- a/src/main/scala/li/cil/oc/integration/opencomputers/DriverUpgradeBarcodeReader.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/DriverUpgradeBarcodeReader.scala
@@ -1,0 +1,27 @@
+package li.cil.oc.integration.opencomputers
+
+import li.cil.oc.Constants
+import li.cil.oc.api.driver.EnvironmentProvider
+import li.cil.oc.api
+import li.cil.oc.api.driver.item.{HostAware, Slot}
+import li.cil.oc.api.network.{EnvironmentHost, ManagedEnvironment}
+import li.cil.oc.server.component
+import li.cil.oc.server.component.UpgradeBarcodeReader
+import net.minecraft.item.ItemStack
+
+object DriverUpgradeBarcodeReader extends Item with HostAware {
+  override def worksWith(stack: ItemStack) = isOneOf(stack,
+    api.Items.get(Constants.ItemName.Analyzer))
+
+  override def createEnvironment(stack: ItemStack, host: EnvironmentHost): ManagedEnvironment =
+    new UpgradeBarcodeReader(host)
+
+  override def slot(stack: ItemStack) = Slot.Upgrade
+
+  object Provider extends EnvironmentProvider {
+    override def getEnvironment(stack: ItemStack): Class[_] =
+      if (worksWith(stack))
+        classOf[component.UpgradeBarcodeReader]
+      else null
+  }
+}

--- a/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/ModOpenComputers.scala
@@ -151,6 +151,7 @@ object ModOpenComputers extends ModProxy {
     api.Driver.add(DriverTerminalServer)
 
     api.Driver.add(DriverUpgradeAngel)
+    api.Driver.add(DriverUpgradeBarcodeReader)
     api.Driver.add(DriverUpgradeBattery)
     api.Driver.add(DriverUpgradeChunkloader)
     api.Driver.add(DriverUpgradeCrafting)
@@ -212,6 +213,7 @@ object ModOpenComputers extends ModProxy {
       Constants.BlockName.ScreenTier1,
       Constants.BlockName.Transposer,
       Constants.BlockName.CarpetedCapacitor,
+      Constants.ItemName.Analyzer,
       Constants.ItemName.AngelUpgrade,
       Constants.ItemName.BatteryUpgradeTier1,
       Constants.ItemName.BatteryUpgradeTier2,
@@ -235,6 +237,7 @@ object ModOpenComputers extends ModProxy {
       Constants.BlockName.ScreenTier1,
       Constants.BlockName.Transposer,
       Constants.BlockName.CarpetedCapacitor,
+      Constants.ItemName.Analyzer,
       Constants.ItemName.APUTier1,
       Constants.ItemName.APUTier2,
       Constants.ItemName.GraphicsCardTier1,
@@ -250,6 +253,7 @@ object ModOpenComputers extends ModProxy {
       Constants.BlockName.Keyboard,
       Constants.BlockName.ScreenTier1,
       Constants.BlockName.CarpetedCapacitor,
+      Constants.ItemName.Analyzer,
       Constants.ItemName.APUTier1,
       Constants.ItemName.APUTier2,
       Constants.ItemName.GraphicsCardTier1,
@@ -275,6 +279,7 @@ object ModOpenComputers extends ModProxy {
     blacklistHost(classOf[internal.Robot],
       Constants.BlockName.Transposer,
       Constants.BlockName.CarpetedCapacitor,
+      Constants.ItemName.Analyzer,
       Constants.ItemName.LeashUpgrade)
     blacklistHost(classOf[internal.Tablet],
       Constants.BlockName.ScreenTier1,

--- a/src/main/scala/li/cil/oc/server/component/UpgradeBarcodeReader.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeBarcodeReader.scala
@@ -1,0 +1,77 @@
+package li.cil.oc.server.component
+
+import java.util
+
+import li.cil.oc.{Constants, OpenComputers, api}
+import li.cil.oc.api.driver.DeviceInfo
+import li.cil.oc.api.driver.DeviceInfo.DeviceAttribute
+import li.cil.oc.api.driver.DeviceInfo.DeviceClass
+import li.cil.oc.api.internal
+import li.cil.oc.api.network._
+import li.cil.oc.api.prefab
+import li.cil.oc.util.BlockPosition
+import li.cil.oc.util.ExtendedWorld._
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.nbt.NBTTagList
+import net.minecraft.util.EnumFacing
+import net.minecraft.world.WorldServer
+import net.minecraftforge.common.util.ForgeDirection
+
+import scala.collection.convert.WrapAsJava._
+
+class UpgradeBarcodeReader(val host: EnvironmentHost) extends prefab.ManagedEnvironment with DeviceInfo {
+  override val node = api.Network.newNode(this, Visibility.Network).
+    withComponent("barcode_reader").
+    withConnector().
+    create()
+
+  private final lazy val deviceInfo = Map(
+    DeviceAttribute.Class -> DeviceClass.Generic,
+    DeviceAttribute.Description -> "Barcode reader upgrade",
+    DeviceAttribute.Vendor -> Constants.DeviceInfo.DefaultVendor,
+    DeviceAttribute.Product -> "Readerizer Deluxe"
+  )
+
+  override def getDeviceInfo: util.Map[String, String] = deviceInfo
+
+  override def onMessage(message: Message): Unit = {
+    super.onMessage(message)
+    if (message.name == "tablet.use") message.source.host match {
+      case machine: api.machine.Machine => (machine.host, message.data) match {
+        case (tablet: internal.Tablet, Array(nbt: NBTTagCompound, stack: ItemStack, player: EntityPlayer, blockPos: BlockPosition, side: ForgeDirection, hitX: java.lang.Float, hitY: java.lang.Float, hitZ: java.lang.Float)) =>
+          host.world.getTileEntity(blockPos) match {
+            case analyzable: Analyzable =>
+              processNodes(analyzable.onAnalyze(player, side.ordinal(), hitX.toFloat, hitY.toFloat, hitZ.toFloat), nbt)
+            case host: SidedEnvironment =>
+              processNodes(Array(host.sidedNode(side)), nbt)
+            case host: Environment =>
+              processNodes(Array(host.node), nbt)
+          }
+      }
+    }
+  }
+
+  private def processNodes(nodes: Array[Node], nbt: NBTTagCompound): Unit = if (nodes != null) {
+    val readerNBT = new NBTTagList()
+
+    for (node <- nodes if node != null) {
+      val nodeNBT = new NBTTagCompound()
+      node match {
+        case component: Component =>
+          nodeNBT.setString("type", component.name)
+        case _ =>
+      }
+
+      val address = node.address()
+      if (address != null && !address.isEmpty) {
+        nodeNBT.setString("address", node.address())
+      }
+
+      readerNBT.appendTag(nodeNBT)
+    }
+
+    nbt.setTag("analyzed", readerNBT)
+  }
+}


### PR DESCRIPTION
This is a first, MVP, pass at a "Barcode Reader" tablet upgrade. I've confirmed it works with both a single-node device, as well as a multi-node device ( such as an adapter ).

Things still to do:

  - [x] Blacklist it from non-tablet devices ( Or make it work with non-tablet devices)
  - [x] Multiplayer testing
  - [x] A sprite would be nice.
  - [x] (For non-components) Make it possible to get internal component's addresses (such as modems)
    - I'd like some feedback for this part.

The logic behind it for "immersion" for me is often devices will come with a barcode on the back of the unit or on the packaging for the MAC address of the device, for network set up purposes, so I'm working with the idea that that translates to the device's component address.

![Picture of it working](https://nc.ddna.co/s/jq2AEgAEWsYdsY3/preview)