### PR TITLE
Fixed some container names being unlocalized on 1.11+

### DIFF
--- a/src/main/scala/li/cil/oc/common/inventory/DatabaseInventory.scala
+++ b/src/main/scala/li/cil/oc/common/inventory/DatabaseInventory.scala
@@ -9,7 +9,7 @@ trait DatabaseInventory extends ItemStackInventory {
 
   override def getSizeInventory = Settings.get.databaseEntriesPerTier(tier)
 
-  override protected def inventoryName = "Database"
+  override protected def inventoryName = "database"
 
   override def getInventoryStackLimit = 1
 

--- a/src/main/scala/li/cil/oc/common/inventory/DiskDriveMountableInventory.scala
+++ b/src/main/scala/li/cil/oc/common/inventory/DiskDriveMountableInventory.scala
@@ -10,7 +10,7 @@ trait DiskDriveMountableInventory extends ItemStackInventory {
 
   override def getSizeInventory = 1
 
-  override protected def inventoryName = "DiskDrive"
+  override protected def inventoryName = "diskdrive"
 
   override def getInventoryStackLimit = 1
 

--- a/src/main/scala/li/cil/oc/common/inventory/ServerInventory.scala
+++ b/src/main/scala/li/cil/oc/common/inventory/ServerInventory.scala
@@ -12,7 +12,7 @@ trait ServerInventory extends ItemStackInventory {
 
   override def getSizeInventory = InventorySlots.server(tier).length
 
-  override protected def inventoryName = "Server"
+  override protected def inventoryName = "server"
 
   override def getInventoryStackLimit = 1
 


### PR DESCRIPTION
In 1.11 the lang keys for the container names were converted to lowercase, but there were some hard coded values in the inventories for servers, rack-mounted disk drives, and database upgrades that still were in uppercase. The other inventories are OK because they use the classname in lowercase as its lang key.