### PR TITLE
Fixed AE2 integration when AE2's channels are disabled

### DIFF
--- a/src/main/scala/li/cil/oc/integration/appeng/AEUtil.scala
+++ b/src/main/scala/li/cil/oc/integration/appeng/AEUtil.scala
@@ -22,11 +22,13 @@ object AEUtil {
 
   def useNewItemDefinitionAPI = versionsWithNewItemDefinitionAPI.containsVersion(
     Loader.instance.getIndexedModList.get(Mods.AppliedEnergistics2.id).getProcessedVersion)
+	
+  def areChannelsEnabled: Boolean = AEApi.instance != null && AEApi.instance.definitions.blocks.controller.maybeStack(1).isPresent
 
   // ----------------------------------------------------------------------- //
 
   def controllerClass: Class[_] =
-    if (AEApi.instance != null)
+    if (AEApi.instance != null && areChannelsEnabled)
       AEApi.instance.definitions.blocks.controller.maybeEntity.get()
     else null: Class[_]
 
@@ -39,7 +41,7 @@ object AEUtil {
 
   // ----------------------------------------------------------------------- //
 
-  def isController(stack: ItemStack): Boolean = stack != null && AEApi.instance != null && AEApi.instance.definitions.blocks.controller.isSameAs(stack)
+  def isController(stack: ItemStack): Boolean = stack != null && AEApi.instance != null && areChannelsEnabled && AEApi.instance.definitions.blocks.controller.isSameAs(stack)
 
   // ----------------------------------------------------------------------- //
 


### PR DESCRIPTION
I believe I properly fixed the issue referenced in #3090 

[The previous fix](https://github.com/MightyPirates/OpenComputers/commit/e660aeceddb72d477293dfa49ec8e860d58da998) did not seem to correctly fix the issue, and resulted in a `NoSuchElementException` being thrown when attempting to connect an adapter to an AE2 ME Interface, when AE2's channels were disabled. Controllers don't exist when channels are disabled, thus the exception.

Prior to that commit, it checked if ME Controllers exist before defining the integration for both ME Controllers *and* ME Interfaces. For controllers this check was necessary, but not for interfaces. The fix removed the checks from both.

By re-implementing the check *only* when defining ME Controllers, this fixed the exception and allows ME Interfaces to be used when channels are disabled.

Sorry for the potentially poor description!