### PR TITLE
Added Ordis (Warframe)

### DIFF
--- a/src/main/resources/assets/opencomputers/robot.names
+++ b/src/main/resources/assets/opencomputers/robot.names
@@ -88,6 +88,7 @@ Michiyo            # Contributor
 Mycroft Holmes     # The Moon Is a Harsh Mistress
 Pac-Man            # Pac-Man
 Optimus            # Transformers. Seperated "Optimus Prime" into two names, as both are quite fitting robot names.
+Ordis              # Warframe
 P-Body             # Portal
 Pintsize           # Questionable Content
 PixelToast         # Contributor


### PR DESCRIPTION
In the wiki: https://warframe.fandom.com/wiki/Ordis
Ordis is a cephalon which is the name for the forms of artificial intelligence in Warframe ( https://warframe.fandom.com/wiki/Cephalon ).