### PR TITLE
Added Samuel Hayden from DOOM (2016)

### DIFF
--- a/src/main/resources/assets/opencomputers/robot.names
+++ b/src/main/resources/assets/opencomputers/robot.names
@@ -101,6 +101,7 @@ Replicator         # Stargate
 Robby              # Forbidden Planet
 Roomba             # Under your couch... wait.
 Rosie              # The Jetsons
+Samuel Hayden      # DOOM (2016)
 Skaffen-Amtiskaw   # Use of weapons (Iain M Banks)
 Shakey             # The first general-purpose mobile robot that could reason about its actions.
 SHODAN             # System Shock


### PR DESCRIPTION
Wiki article: https://doom.fandom.com/wiki/Samuel_Hayden

Hayden oversaw the Argent Energy project on the UAC Mars base. He acquired his robotic form to avoid death after being diagnosed with an incurable brain tumor.

He counts, right?