### PR TITLE
Use rawequal for comparison in pcallTimeoutCheck

### DIFF
--- a/src/main/resources/assets/opencomputers/lua/machine.lua
+++ b/src/main/resources/assets/opencomputers/lua/machine.lua
@@ -54,7 +54,7 @@ local function checkDeadline()
 end
 local function pcallTimeoutCheck(...)
   local ok, timeout = ...
-  if timeout == tooLongWithoutYielding then
+  if rawequal(timeout, tooLongWithoutYielding) then
     return ok, tostring(tooLongWithoutYielding)
   end
   return ...


### PR DESCRIPTION
In `pcallTimeoutCheck`, the second argument may have the `__eq` metamethod defined. If it returns `true`, the value is erroneously replaced with `"too long without yielding"`, which can break some scripts. `rawequal` should be used instead to check for equality without invoking the metamethod.