### PR TITLE
Fix OpenOS '/bin/sh cmd' failing due to lack of env table

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/sh.lua
@@ -41,16 +41,14 @@ if #args == 0 then
   end
 else
   -- execute command.
-  local cargs = table.pack(...)
+  local cargs = {...}
   -- sh can run as a shell command (no env table)
   local cenv = _ENV
-  local cargsStart = 1
   if type(cargs[1]) == "table" then
     -- sh can also run as a manually started process (see /bin/source.lua)
-    cenv = cargs[1]
-    cargsStart = 2
+    cenv = table.remove(cargs, 1)
   end
-  local result = table.pack(sh.execute(cenv, table.unpack(cargs, cargsStart)))
+  local result = {sh.execute(cenv, table.unpack(cargs))}
   if not result[1] then
     error(result[2], 0)
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/sh.lua
@@ -41,7 +41,16 @@ if #args == 0 then
   end
 else
   -- execute command.
-  local result = table.pack(sh.execute(...))
+  local cargs = table.pack(...)
+  -- sh can run as a shell command (no env table)
+  local cenv = _ENV
+  local cargsStart = 1
+  if type(cargs[1]) == "table" then
+    -- sh can also run as a manually started process (see /bin/source.lua)
+    cenv = cargs[1]
+    cargsStart = 2
+  end
+  local result = table.pack(sh.execute(cenv, table.unpack(cargs, cargsStart)))
   if not result[1] then
     error(result[2], 0)
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/sh.lua
@@ -44,7 +44,7 @@ else
   local cargs = {...}
   -- sh can run as a shell command (no env table)
   local cenv = _ENV
-  if type(cargs[1]) == "table" then
+  if cargs[1] == nil or type(cargs[1]) == "table" then
     -- sh can also run as a manually started process (see /bin/source.lua)
     cenv = table.remove(cargs, 1)
   end


### PR DESCRIPTION
`/bin/sh.lua` should be able to execute a command passed as an argument, but currently fails to do so in interactive shells as `sh.execute` (in `/lib/sh.lua`) expects an environment table as the first parameter:

![image](https://user-images.githubusercontent.com/1200380/71446867-844c7600-2728-11ea-9c03-6783a0c3eb21.png)

That environment table is given when running commands in the interactive shell, but is missing from the non-interactive `sh.execute` call.

Meanwhile, `/bin/source.lua` passes an environment table as the first argument to `/bin/sh.lua` when starting the `sh` process manually.

As such, I've decided to add a simple check if the first parameter is a table. If it is, it's assumed to be the environment table and won't be passed on. Otherwise `_ENV` will be used and all arguments will be passed on.

![image](https://user-images.githubusercontent.com/1200380/71447493-2f602e00-272f-11ea-8caf-4ef1b93693ca.png)

This should maintain compatibility with any existing usages of `/bin/sh.lua` as a child process. Admittedly, I've only tested it locally by manipulating a copy of `/bin/sh.lua` after installing OpenOS onto an OC computer.

(Sidenote: I was not sure whether to remove the env table from the argument list, or whether to skip it when unpacking the arg list. I went with the second option as I thought it'd be preferred, given how returning does the same.)