### PR TITLE
Switched to Gradle 5 on Minecraft 1.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,20 +9,21 @@ buildscript {
             name = "sonatype"
             url = "https://oss.sonatype.org/content/repositories/snapshots/"
         }
+        maven {
+            url = "https://jitpack.io"
+        }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'com.github.CDAGaming:ForgeGradle:1c670759c5'
+        classpath 'com.github.CDAGaming:CurseGradle:184e4322fd'
     }
-}
-
-plugins {
-    id "com.matthewprenger.cursegradle" version "1.0.9"
 }
 
 apply plugin: 'scala'
 apply plugin: 'forge'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
+apply plugin: 'com.matthewprenger.cursegradle'
 
 file "build.properties" withReader {
     def prop = new Properties()
@@ -77,53 +78,61 @@ repositories {
         name = "mightypirates"
         url = "https://maven.cil.li/"
     }
+    // These are necessary because some parts of the maven repo is weirdly structured, this needs to be fixed.
+    ivy {
+        name 'weird maven repos'
+        artifactPattern "https://maven.cil.li/[module]/[revision]/[module]-[revision].[ext]"
+    }
+    ivy {
+        name 'weird maven repos 2'
+        artifactPattern "https://maven.cil.li/[module]/[revision]/[module]-[revision]-[classifier].[ext]"
+    }
 }
 
 configurations {
-    provided
     embedded
-    compile.extendsFrom embedded
+    implementation.extendsFrom embedded
 }
 
 dependencies {
-    provided "appeng:RotaryCraft:${config.rotc.version}:api"
-    provided ("appeng:appliedenergistics2:${config.ae2.version}:dev") {
+    compileOnly "appeng:RotaryCraft:${config.rotc.version}:api"
+    compileOnly ("appeng:appliedenergistics2:${config.ae2.version}:dev") {
         exclude module: 'buildcraft'
     }
-    provided "codechicken:CodeChickenLib:${config.minecraft.version}-${config.ccl.version}:dev"
-    provided "codechicken:EnderStorage:${config.minecraft.version}-${config.es.version}:dev"
-    provided "codechicken:ForgeMultipart:${config.minecraft.version}-${config.fmp.version}:dev"
-    provided "codechicken:NotEnoughItems:${config.minecraft.version}-${config.nei.version}:dev"
-    provided "codechicken:WR-CBE:${config.minecraft.version}-${config.wrcbe.version}:dev"
-    provided "com.bluepowermod:BluePower:${config.bluepower.version}:deobf"
-    provided "com.gregoriust.gregtech:gregtech_${config.minecraft.version}:${config.gt.version}:dev"
-    provided "igwmod:IGW-Mod-1.7.10:${config.igwmod.version}:userdev"
-    provided "li.cil.tis3d:TIS-3D:${config.tis3d.version}:dev"
-    provided "mcp.mobius.waila:Waila:${config.waila.version}_${config.minecraft.version}:dev"
-    provided "net.industrial-craft:industrialcraft-2:${config.ic2.version}:dev"
-    provided "net.sengir.forestry:forestry_${config.minecraft.version}:${config.forestry.version}:dev"
-    provided "dev.modwarriors.notenoughkeys:NotEnoughKeys:${config.minecraft.version}-${config.nek.version}:deobf-dev"
-    provided "qmunity:QmunityLib:${config.qmunitylib.version}:deobf"
-    provided "tmech:TMechworks:${config.minecraft.version}-${config.tmech.version}:deobf"
-    provided ("mrtjp:ProjectRed:${config.projred.version}:dev") {
+    compileOnly "codechicken:CodeChickenLib:${config.minecraft.version}-${config.ccl.version}:dev"
+    compileOnly "codechicken:EnderStorage:${config.minecraft.version}-${config.es.version}:dev"
+    compileOnly "codechicken:ForgeMultipart:${config.minecraft.version}-${config.fmp.version}:dev"
+    compileOnly "codechicken:NotEnoughItems:${config.minecraft.version}-${config.nei.version}:dev"
+    compileOnly "codechicken:WR-CBE:${config.minecraft.version}-${config.wrcbe.version}:dev"
+    compileOnly "com.bluepowermod:BluePower:${config.bluepower.version}:deobf"
+    compileOnly "com.gregoriust.gregtech:gregtech_${config.minecraft.version}:${config.gt.version}:dev"
+    compileOnly "igwmod:IGW-Mod-1.7.10:${config.igwmod.version}:userdev"
+    compileOnly "li.cil.tis3d:TIS-3D:${config.tis3d.version}:dev"
+    compileOnly "mcp.mobius.waila:Waila:${config.waila.version}_${config.minecraft.version}:dev"
+    compileOnly "net.industrial-craft:industrialcraft-2:${config.ic2.version}:dev"
+    compileOnly "net.sengir.forestry:forestry_${config.minecraft.version}:${config.forestry.version}:dev"
+    compileOnly "dev.modwarriors.notenoughkeys:NotEnoughKeys:${config.minecraft.version}-${config.nek.version}:deobf-dev"
+    compileOnly "qmunity:QmunityLib:${config.qmunitylib.version}:deobf"
+    compileOnly "tmech:TMechworks:${config.minecraft.version}-${config.tmech.version}:deobf"
+    compileOnly ("mrtjp:ProjectRed:${config.projred.version}:dev") {
         exclude module: 'CoFHCore'
     }
-    // provided "coloredlightscore:ColoredLightsCore:${config.coloredlights.version}:api"
+    // compileOnly "coloredlightscore:ColoredLightsCore:${config.coloredlights.version}:api"
 
-    provided name: 'buildcraft', version: config.bc.version, classifier: "dev", ext: 'jar'
-    provided name: 'GalacticraftCoreAll', version: config.gc.version, ext: 'jar'
-    provided name: 'MekanismAll', version: config.mekanism.version, ext: 'jar'
-    provided name: 'redlogic', version: config.redlogic.version, ext: 'jar'
+    compileOnly name: 'buildcraft', version: config.bc.version, classifier: "dev", ext: 'jar'
+    compileOnly name: 'GalacticraftCoreAll', version: config.gc.version, ext: 'jar'
+    compileOnly name: 'MekanismAll', version: config.mekanism.version, ext: 'jar'
+    compileOnly name: 'redlogic', version: config.redlogic.version, ext: 'jar'
 
-    provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
-    provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
-    provided name: 'MineFactoryReloaded', version: config.mfr.version, ext: 'jar'
-    provided name: 'ComputerCraft', version: config.cc.version, ext: 'jar'
-    provided name: 'EnderIO', version: config.eio.version, ext: 'jar'
-    provided name: 'Railcraft', version: config.rc.version, ext: 'jar'
-    provided name: 'BloodMagic', version: config.bloodmagic.version, ext: 'jar'
-    provided name: 'ExtraCells', version: config.ec.version, ext: 'jar'
-	provided name: 'ThaumicEnergistics', version: config.thaumicenergistics.version, ext: 'jar'
+    compileOnly name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
+    compileOnly name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
+    compileOnly name: 'MineFactoryReloaded', version: config.mfr.version, ext: 'jar'
+    compileOnly name: 'ComputerCraft', version: config.cc.version, ext: 'jar'
+    compileOnly name: 'EnderIO', version: config.eio.version, ext: 'jar'
+    compileOnly name: 'Railcraft', version: config.rc.version, ext: 'jar'
+    compileOnly name: 'BloodMagic', version: config.bloodmagic.version, ext: 'jar'
+    compileOnly name: 'ExtraCells', version: config.ec.version, ext: 'jar'
+	compileOnly name: 'ThaumicEnergistics', version: config.thaumicenergistics.version, ext: 'jar'
 
     compile 'com.google.code.findbugs:jsr305:1.3.9' // Annotations used by google libs.
 
@@ -133,13 +142,6 @@ dependencies {
     testCompile "org.scalactic:scalactic_2.11:2.2.6"
     testCompile "org.scalatest:scalatest_2.11:2.2.6"
 }
-
-// Add the "provided" dependencies to the compile (but NOT runtime) classpath.
-sourceSets.main.compileClasspath += [configurations.provided]
-
-idea.module.scopes.PROVIDED.plus += [configurations.provided]
-// TODO Causes errors on Gradle 2 for me (No such property: allDependencies for class: java.io.File).
-//eclipse.classpath.plusConfigurations += [configurations.provided]
 
 minecraft {
     version = "${config.minecraft.version}-${config.forge.version}"
@@ -255,6 +257,7 @@ curseforge {
         changelog = file("changelog.md")
         addGameVersion config.minecraft.version
         addGameVersion "Java 8"
+        mainArtifact jar
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip


### PR DESCRIPTION
Using a fork of ForgeGradle and CurseGradle which made the plugins compatible with Gradle 5. Huge thanks to @CDAGaming for helping with getting this working. Now OpenComputers should build fine in current versions of IntelliJ again, and hopefully still build fine on jenkins.

Lines 81 through 89 are a hack for now because the dependencies in line 122 and onward do not follow a proper maven directory structure and thus cannot be found by gradle anymore. We have to fix this in the future.

Please test this to see if it works for you.