### PR TITLE
Downgraded Ubuntu version on travis to hopefully fix #3144.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: scala
 scala: 2.11.1
 jdk: oraclejdk8
+dist: trusty
 
 notifications:
   email: false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip


### PR DESCRIPTION
Should fix #3144 and get travis working on 1.7.10 again, according to the research I did. Let's hope so.

Also switched the gradle wrapper to HTTPS because HTTP no longer lets you download anything.