### PR TITLE
Added binary data support to 'text.internal.reader'

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_text.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_text.lua
@@ -181,7 +181,7 @@ function text.internal.reader(txt, mode)
   }, {__index=text.internal.stream_base((mode or ""):match("b"))})
   process.closeOnExit(reader)
 
-  return require("buffer").new(more or "r", reader)
+  return require("buffer").new(mode or "r", reader)
 end
 
 function text.internal.writer(ostream, mode, append_txt)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_text.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_text.lua
@@ -181,7 +181,7 @@ function text.internal.reader(txt, mode)
   }, {__index=text.internal.stream_base((mode or ""):match("b"))})
   process.closeOnExit(reader)
 
-  return require("buffer").new("r", reader)
+  return require("buffer").new(more or "r", reader)
 end
 
 function text.internal.writer(ostream, mode, append_txt)


### PR DESCRIPTION
Mode flag is not passed through to the buffer when creating the reader.
Causes binary files in `devfs` to not function as expected, since they are read as non binary files.