### PR TITLE
Make waypoints more safe

### DIFF
--- a/src/main/scala/li/cil/oc/client/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/client/PacketHandler.scala
@@ -791,7 +791,9 @@ object PacketHandler extends CommonPacketHandler {
 
   def onWaypointLabel(p: PacketParser) =
     p.readTileEntity[Waypoint]() match {
-      case Some(waypoint) => waypoint.label = p.readUTF()
+      case Some(waypoint) if waypoint.playersWhoCanEdit.contains(p.player.getPersistentID) =>
+        waypoint.label = p.readUTF()
+        waypoint.playersWhoCanEdit -= p.player.getPersistentID
       case _ => // Invalid packet.
     }
 }

--- a/src/main/scala/li/cil/oc/common/block/Waypoint.scala
+++ b/src/main/scala/li/cil/oc/common/block/Waypoint.scala
@@ -27,6 +27,13 @@ class Waypoint extends RedstoneAware {
     if (!player.isSneaking) {
       if (world.isRemote) {
         player.openGui(OpenComputers, GuiType.Waypoint.id, world, x, y, z)
+      } else {
+        // If evaluation came here then  protective mods and plugins is allow interaction
+        world.getTileEntity(x, y, z) match {
+          case proxy: tileentity.Waypoint =>
+            proxy.playersWhoCanEdit += player.getPersistentID
+          case _ =>
+        }
       }
       true
     }

--- a/src/main/scala/li/cil/oc/common/tileentity/Waypoint.scala
+++ b/src/main/scala/li/cil/oc/common/tileentity/Waypoint.scala
@@ -1,5 +1,7 @@
 package li.cil.oc.common.tileentity
 
+import java.util.UUID
+
 import cpw.mods.fml.relauncher.Side
 import cpw.mods.fml.relauncher.SideOnly
 import li.cil.oc.Settings
@@ -13,12 +15,16 @@ import li.cil.oc.server.network.Waypoints
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.common.util.ForgeDirection
 
+import scala.collection.mutable
+
 class Waypoint extends traits.Environment with traits.Rotatable with traits.RedstoneAware {
   val node = api.Network.newNode(this, Visibility.Network).
     withComponent("waypoint").
     create()
 
   var label = ""
+
+  val playersWhoCanEdit = new mutable.HashSet[UUID]()
 
   override def validFacings: Array[ForgeDirection] = ForgeDirection.VALID_DIRECTIONS
 

--- a/src/main/scala/li/cil/oc/server/component/UpgradeNavigation.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeNavigation.scala
@@ -83,7 +83,8 @@ class UpgradeNavigation(val host: EnvironmentHost with Rotatable) extends prefab
       Map(
         "position" -> Array(delta.xCoord, delta.yCoord, delta.zCoord),
         "redstone" -> waypoint.maxInput,
-        "label" -> waypoint.label
+        "label" -> waypoint.label,
+        "address" -> waypoint.node.address()
       )
     }).toArray)
   }


### PR DESCRIPTION
Discussion: https://github.com/MightyPirates/OpenComputers/issues/3208

Changes:

- navigation#findWaypoints gives addresses of waypoints also - it can be used for verification
- label of waypoint can't be changed by player, who do not have access to concrete waypoint block(like generalised support for WorldGuard and similar protective plugins and mods)

Label protection are use same method like vanilla sign