### PR TITLE
Support for non-BMP codepoints

### DIFF
--- a/src/main/java/li/cil/oc/api/internal/TextBuffer.java
+++ b/src/main/java/li/cil/oc/api/internal/TextBuffer.java
@@ -301,8 +301,23 @@ public interface TextBuffer extends ManagedEnvironment, Persistable {
      * @param width  the width of the area to fill.
      * @param height the height of the area to fill.
      * @param value  the character to fill the area with.
+     * @deprecated Please use the int variant.
      */
+    @Deprecated
     void fill(int column, int row, int width, int height, char value);
+
+    /**
+     * Fill a portion of the text buffer.
+     * <p/>
+     * This will set the area's colors to the currently active ones.
+     *
+     * @param column the starting horizontal index of the area to fill.
+     * @param row    the starting vertical index of the area to fill.
+     * @param width  the width of the area to fill.
+     * @param height the height of the area to fill.
+     * @param value  the code point to fill the area with.
+     */
+    void fill(int column, int row, int width, int height, int value);
 
     /**
      * Write a string into the text buffer.
@@ -322,8 +337,19 @@ public interface TextBuffer extends ManagedEnvironment, Persistable {
      * @param column the horizontal index.
      * @param row    the vertical index.
      * @return the character at that index.
+     * @deprecated Please use getCodePoint going forward.
      */
+    @Deprecated
     char get(int column, int row);
+
+    /**
+     * Get the code point in the text buffer at the specified location.
+     *
+     * @param column the horizontal index.
+     * @param row    the vertical index.
+     * @return the character at that index.
+     */
+    int getCodePoint(int column, int row);
 
     /**
      * Get the foreground color of the text buffer at the specified location.
@@ -385,8 +411,31 @@ public interface TextBuffer extends ManagedEnvironment, Persistable {
      * @param column the horizontal index.
      * @param row    the vertical index.
      * @param text   the text to write.
+     * @deprecated Please use the int[][] variant.
      */
+    @Deprecated
     void rawSetText(int column, int row, char[][] text);
+
+    /**
+     * Overwrites a portion of the text in raw mode.
+     * <p/>
+     * This will copy the given char array into the buffer, starting at the
+     * specified column and row. The array is expected to be indexed row-
+     * first, i.e. the first dimension is the vertical axis, the second
+     * the horizontal.
+     * <p/>
+     * <em>Important</em>: this performs no checks as to whether something
+     * actually changed. It will always send the changed patch to clients.
+     * It will also not crop the specified array to the actually used range.
+     * In other words, this is not intended to be exposed as-is to user code,
+     * it should always be called with validated, and, as necessary, cropped
+     * values.
+     *
+     * @param column the horizontal index.
+     * @param row    the vertical index.
+     * @param text   the text code points to write.
+     */
+    void rawSetText(int column, int row, int[][] text);
 
     /**
      * Overwrites a portion of the foreground color information in raw mode.

--- a/src/main/scala/li/cil/oc/client/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/client/PacketHandler.scala
@@ -692,7 +692,7 @@ object PacketHandler extends CommonPacketHandler {
     val row = p.readInt()
     val w = p.readInt()
     val h = p.readInt()
-    val c = p.readChar()
+    val c = p.readMedium()
     buffer.fill(col, row, w, h, c)
   }
 
@@ -733,12 +733,12 @@ object PacketHandler extends CommonPacketHandler {
     val row = p.readInt()
 
     val rows = p.readShort()
-    val text = new Array[Array[Char]](rows)
+    val text = new Array[Array[Int]](rows)
     for (y <- 0 until rows) {
       val cols = p.readShort()
-      val line = new Array[Char](cols)
+      val line = new Array[Int](cols)
       for (x <- 0 until cols) {
-        line(x) = p.readChar()
+        line(x) = p.readMedium()
       }
       text(y) = line
     }

--- a/src/main/scala/li/cil/oc/client/renderer/font/DynamicFontRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/font/DynamicFontRenderer.scala
@@ -25,7 +25,7 @@ class DynamicFontRenderer extends TextureFontRenderer with IResourceManagerReloa
 
   private val textures = mutable.ArrayBuffer.empty[CharTexture]
 
-  private val charMap = mutable.Map.empty[Char, DynamicFontRenderer.CharIcon]
+  private val charMap = mutable.Map.empty[Int, DynamicFontRenderer.CharIcon]
 
   private var activeTexture: CharTexture = _
 
@@ -64,18 +64,18 @@ class DynamicFontRenderer extends TextureFontRenderer with IResourceManagerReloa
     RenderState.checkError(getClass.getName + ".bindTexture")
   }
 
-  override protected def generateChar(char: Char) {
+  override protected def generateChar(char: Int) {
     charMap.getOrElseUpdate(char, createCharIcon(char))
   }
 
-  override protected def drawChar(tx: Float, ty: Float, char: Char) {
+  override protected def drawChar(tx: Float, ty: Float, char: Int) {
     charMap.get(char) match {
       case Some(icon) if icon.texture == activeTexture => icon.draw(tx, ty)
       case _ =>
     }
   }
 
-  private def createCharIcon(char: Char): DynamicFontRenderer.CharIcon = {
+  private def createCharIcon(char: Int): DynamicFontRenderer.CharIcon = {
     if (FontUtils.wcwidth(char) < 1 || glyphProvider.getGlyph(char) == null) {
       if (char == '?') null
       else charMap.getOrElseUpdate('?', createCharIcon('?'))
@@ -127,9 +127,9 @@ object DynamicFontRenderer {
       RenderState.bindTexture(id)
     }
 
-    def isFull(char: Char) = chars + FontUtils.wcwidth(char) > capacity
+    def isFull(char: Int) = chars + FontUtils.wcwidth(char) > capacity
 
-    def add(char: Char) = {
+    def add(char: Int) = {
       val glyphWidth = FontUtils.wcwidth(char)
       val w = owner.charWidth * glyphWidth
       val h = owner.charHeight

--- a/src/main/scala/li/cil/oc/client/renderer/font/StaticFontRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/font/StaticFontRenderer.scala
@@ -50,7 +50,7 @@ class StaticFontRenderer extends TextureFontRenderer {
     }
   }
 
-  override protected def drawChar(tx: Float, ty: Float, char: Char) {
+  override protected def drawChar(tx: Float, ty: Float, char: Int) {
     val index = 1 + (chars.indexOf(char) match {
       case -1 => chars.indexOf('?')
       case i => i
@@ -69,5 +69,5 @@ class StaticFontRenderer extends TextureFontRenderer {
     GL11.glVertex3d(tx - dw, ty - dh, 0)
   }
 
-  override protected def generateChar(char: Char) {}
+  override protected def generateChar(char: Int) {}
 }

--- a/src/main/scala/li/cil/oc/client/renderer/font/TextureFontRenderer.scala
+++ b/src/main/scala/li/cil/oc/client/renderer/font/TextureFontRenderer.scala
@@ -32,6 +32,13 @@ abstract class TextureFontRenderer {
     }
   }
 
+  def generateChars(chars: Array[Int]) {
+    GlStateManager.enableTexture2D()
+    for (char <- chars) {
+      generateChar(char)
+    }
+  }
+
   def drawBuffer(buffer: TextBuffer, viewportWidth: Int, viewportHeight: Int) {
     val format = buffer.format
 
@@ -120,6 +127,8 @@ abstract class TextureFontRenderer {
   }
 
   def drawString(s: String, x: Int, y: Int): Unit = {
+    val sLength = s.codePointCount(0, s.length)
+
     GlStateManager.pushMatrix()
     RenderState.pushAttrib()
 
@@ -131,8 +140,8 @@ abstract class TextureFontRenderer {
       bindTexture(i)
       GL11.glBegin(GL11.GL_QUADS)
       var tx = 0f
-      for (n <- 0 until s.length) {
-        val ch = s.charAt(n)
+      for (n <- 0 until sLength) {
+        val ch = s.codePointAt(n)
         // Don't render whitespace.
         if (ch != ' ') {
           drawChar(tx, 0, ch)
@@ -155,9 +164,9 @@ abstract class TextureFontRenderer {
 
   protected def bindTexture(index: Int): Unit
 
-  protected def generateChar(char: Char): Unit
+  protected def generateChar(char: Int): Unit
 
-  protected def drawChar(tx: Float, ty: Float, char: Char): Unit
+  protected def drawChar(tx: Float, ty: Float, char: Int): Unit
 
   private def drawQuad(color: Int, x: Int, y: Int, width: Int) = if (color != 0 && width > 0) {
     val x0 = x * charWidth

--- a/src/main/scala/li/cil/oc/common/PacketBuilder.scala
+++ b/src/main/scala/li/cil/oc/common/PacketBuilder.scala
@@ -58,6 +58,12 @@ abstract class PacketBuilder(stream: OutputStream) extends DataOutputStream(stre
     }
   }
 
+  def writeMedium(v: Int) = {
+    writeByte(v & 0xFF)
+    writeByte((v >> 8) & 0xFF)
+    writeByte((v >> 16) & 0xFF)
+  }
+
   def writePacketType(pt: PacketType.Value) = writeByte(pt.id)
 
   def sendToAllPlayers() = OpenComputers.channel.sendToAll(packet)

--- a/src/main/scala/li/cil/oc/common/PacketHandler.scala
+++ b/src/main/scala/li/cil/oc/common/PacketHandler.scala
@@ -149,6 +149,13 @@ abstract class PacketHandler {
       else null
     }
 
+    def readMedium(): Int = {
+      val c0 = readUnsignedByte()
+      val c1 = readUnsignedByte()
+      val c2 = readUnsignedByte()
+      (c0) | (c1 << 8) | (c2 << 16)
+    }
+
     def readPacketType() = PacketType(readByte())
   }
 

--- a/src/main/scala/li/cil/oc/server/PacketSender.scala
+++ b/src/main/scala/li/cil/oc/server/PacketSender.scala
@@ -623,14 +623,14 @@ object PacketSender {
     pb.writeInt(value.ordinal)
   }
 
-  def appendTextBufferFill(pb: PacketBuilder, col: Int, row: Int, w: Int, h: Int, c: Char) {
+  def appendTextBufferFill(pb: PacketBuilder, col: Int, row: Int, w: Int, h: Int, c: Int) {
     pb.writePacketType(PacketType.TextBufferMultiFill)
 
     pb.writeInt(col)
     pb.writeInt(row)
     pb.writeInt(w)
     pb.writeInt(h)
-    pb.writeChar(c)
+    pb.writeMedium(c)
   }
 
   def appendTextBufferPaletteChange(pb: PacketBuilder, index: Int, color: Int) {
@@ -670,7 +670,7 @@ object PacketSender {
     pb.writeBoolean(vertical)
   }
 
-  def appendTextBufferRawSetText(pb: PacketBuilder, col: Int, row: Int, text: Array[Array[Char]]) {
+  def appendTextBufferRawSetText(pb: PacketBuilder, col: Int, row: Int, text: Array[Array[Int]]) {
     pb.writePacketType(PacketType.TextBufferMultiRawSetText)
 
     pb.writeInt(col)
@@ -680,7 +680,7 @@ object PacketSender {
       val line = text(y)
       pb.writeShort(line.length.toShort)
       for (x <- 0 until line.length.toShort) {
-        pb.writeChar(line(x))
+        pb.writeMedium(line(x))
       }
     }
   }

--- a/src/main/scala/li/cil/oc/server/component/GraphicsCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/GraphicsCard.scala
@@ -270,7 +270,7 @@ class GraphicsCard(val tier: Int) extends AbstractManagedEnvironment with Device
           (bgValue, Unit)
         }
 
-      result(s.get(x, y), fgColor, bgColor, fgIndex, bgIndex)
+      result(new java.lang.StringBuilder().appendCodePoint(s.getCodePoint(x, y)).toString, fgColor, bgColor, fgIndex, bgIndex)
     })
   }
 
@@ -317,11 +317,11 @@ class GraphicsCard(val tier: Int) extends AbstractManagedEnvironment with Device
     val w = math.max(0, args.checkInteger(2))
     val h = math.max(0, args.checkInteger(3))
     val value = args.checkString(4)
-    if (value.length == 1) screen(s => {
-      val c = value.charAt(0)
+    if (value.codePointCount(0, value.length) == 1) screen(s => {
+      val c = value.codePointAt(0)
       val cost = if (c == ' ') Settings.get.gpuClearCost else Settings.get.gpuFillCost
       if (consumePower(w * h, cost)) {
-        s.fill(x, y, w, h, value.charAt(0))
+        s.fill(x, y, w, h, c)
         result(true)
       }
       else {

--- a/src/main/scala/li/cil/oc/util/FontUtils.scala
+++ b/src/main/scala/li/cil/oc/util/FontUtils.scala
@@ -8,14 +8,9 @@ import li.cil.oc.OpenComputers
 
 object FontUtils {
   private val defined_double_wide: BitSet = BitSet()
-  
-  // font.hex actually has some codepoints larger than 0x10000
-  // but, UnicodeAPI.scala is using java's Integer.ToChar which only supports the utf-16 range
-  // and thus will truncate any incoming codepoint, forcing it below 0x10000
-  // I believe the solution is to use StringBuffer.appendCodePoint
-  // but that change would deserve a bit of testing first, postponing for a later update
-  // review http://www.oracle.com/us/technologies/java/supplementary-142654.html
-  val codepoint_limit: Int = 0x10000
+
+  // theoretical Unicode maximum
+  val codepoint_limit: Int = 0x110000
   def wcwidth(charCode: Int): Int = if (defined_double_wide(charCode)) 2 else 1
 
   {


### PR DESCRIPTION
The basic functionality seems to work, but there are a few omissions.

TODO (feel free to take this over):

- [ ] More locations of using .length() over .codePointCount(...) must be fixed
- [x] .codePointAt(x) must be replaced with .codePointAfter(currentIdx) to work correctly in iterators (or use the .codePoints stream, or use .offsetByCodePoints)
- [x] Fix unicode.reverse (uses Scala code which operates on an assumption of an Array[Char])
- [x] Fix unicode.sub (needs to operate based on offsetByCodePoints)

Possibly more?