### PR TITLE
Add boot time information to OpenOS

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/boottime.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/boottime.lua
@@ -1,0 +1,6 @@
+-- print how long it took the system to boot --
+local computer = require("computer")
+
+print("OpenOS booted in " .. computer.bootTime() .. " seconds")
+
+return 0

--- a/src/main/resources/assets/opencomputers/loot/openos/init.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/init.lua
@@ -1,3 +1,4 @@
+local start = computer.uptime()
 do
   local addr, invoke = computer.getBootAddress(), component.invoke
   local function loadfile(file)
@@ -13,6 +14,11 @@ do
   loadfile("/lib/core/boot.lua")(loadfile)
 end
 
+local c = require("computer")
+local time = c.uptime() - start
+function c.bootTime()
+  return time
+end
 while true do
   local result, reason = xpcall(require("shell").getShell(), function(msg)
     return tostring(msg).."\n"..debug.traceback()


### PR DESCRIPTION
Simple addition. Run `boottime` or `computer.bootTime()` to get the time it took OpenOS to boot.