### PR TITLE
Fixed Relay setStrength unlimited upper bound

### DIFF
--- a/src/main/scala/li/cil/oc/common/tileentity/Relay.scala
+++ b/src/main/scala/li/cil/oc/common/tileentity/Relay.scala
@@ -91,7 +91,7 @@ class Relay extends traits.SwitchLike with traits.ComponentInventory with traits
 
   @Callback(doc = """function(strength:number):number -- Set the signal strength (range) used when relaying messages.""")
   def setStrength(context: Context, args: Arguments): Array[AnyRef] = synchronized {
-    strength = math.max(args.checkDouble(0), math.min(0, maxWirelessRange))
+    strength = math.max(0, math.min(args.checkDouble(0), maxWirelessRange))
     result(strength)
   }
 


### PR DESCRIPTION
Range checking while setting the wireless signal strength for Relays was incorrect and unbounded. Behavior now matches that of wireless network cards.