### PR TITLE
barcode-reader: Oops, turns out if you try and scan literally anything else, it'll break the scan.

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/UpgradeBarcodeReader.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeBarcodeReader.scala
@@ -48,8 +48,11 @@ class UpgradeBarcodeReader(val host: EnvironmentHost) extends prefab.ManagedEnvi
               processNodes(Array(host.sidedNode(side)), nbt)
             case host: Environment =>
               processNodes(Array(host.node), nbt)
+            case _ => // Ignore
           }
+          case _ => // Ignore
       }
+      case _ => // Ignore
     }
   }
 


### PR DESCRIPTION
This includes things that would be scanned by other upgrades.