### PR TITLE
[OpenOS] Tiny ls manual fixes

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/ls
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/ls
@@ -45,7 +45,7 @@ OPTIONS
     Do not colorize the output (default colorized)
 
   --help
-    display this help and exit]])
+    display this help and exit
 
   -p
     append / indicator to directories


### PR DESCRIPTION
Removed unnecessary characters in the OpenOS manpage for ls