### PR TITLE
Check the channel is not null before submitting it to the TCPNotifier

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/InternetCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/InternetCard.scala
@@ -246,6 +246,7 @@ object InternetCard {
     private val id = UUID.randomUUID()
 
     private def setupSelector() {
+      if (channel == null) return
       TCPNotifier.add((channel, () => {
         owner match {
           case Some(internetCard) =>


### PR DESCRIPTION
Why the null check is necessary:

1. `checkConnected` closes the channel (and sets it to `null`) if it encounters an error during address resolution.

   https://github.com/MightyPirates/OpenComputers/blob/8b8ddb231989702bf027f102b64ea569e4467bd6/src/main/scala/li/cil/oc/server/component/InternetCard.scala#L342

   https://github.com/MightyPirates/OpenComputers/blob/8b8ddb231989702bf027f102b64ea569e4467bd6/src/main/scala/li/cil/oc/server/component/InternetCard.scala#L314-L317

2. However, `finishConnect` calls `setupSelector` regardless of what `checkConnected` returns.

   https://github.com/MightyPirates/OpenComputers/blob/8b8ddb231989702bf027f102b64ea569e4467bd6/src/main/scala/li/cil/oc/server/component/InternetCard.scala#L265-L266

3. `setupSelector` assumes the `channel` is not `null` and passes it to the `TCPNotifier`.

   https://github.com/MightyPirates/OpenComputers/blob/8b8ddb231989702bf027f102b64ea569e4467bd6/src/main/scala/li/cil/oc/server/component/InternetCard.scala#L252-L253

4. The `TCPNotifier` then tries to match the channel against a pattern that does not expect a `null`.

   https://github.com/MightyPirates/OpenComputers/blob/8b8ddb231989702bf027f102b64ea569e4467bd6/src/main/scala/li/cil/oc/server/component/InternetCard.scala#L199-L200

5. But since it is `null`, the match fails, and the thread crashes.

Being the cause of #3228, it has an unfortunate effect of disabling `internet_ready` on all computers in the world until the server is restarted.

We can't just check if `checkConnected` returns `false`, because this value is ambiguous: it can either mean there is an error or indicate that the connection is not yet established. And we'd still like to set up a selector in the latter case. Therefore I've chosen a less intrusive way to fix the bug, by adding a null check in the `setupSelector` method.

Fixes #3228 