### PR TITLE
Disable debug cards by default

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1559,7 +1559,7 @@ opencomputers {
     # want to enable whitelisting of debug card users (managed by command
     # /oc_debugWhitelist). This will *not* remove the card, it will just
     # make all functions it provides error out.
-    debugCardAccess: allow
+    debugCardAccess: deny
 
     # Whether to always register the LuaJ architecture - even if the native
     # library is available. In that case it is possible to switch between


### PR DESCRIPTION
It's a serious security risk to have debug cards enabled by default. Server admins might not know what they can do and I've also experienced the OC config getting reset if I make a minor error or OC isn't happy with my chunkloading world whitelist/blacklist for whatever reason.

Such events could be catastrophic for creative servers. Also many mods also have packet vulnerabilities that make it possible to spawn in any item.

For these reasons I believe it's critical to have them disabled by default.