### PR TITLE
Block 0.0.0.0/8 from internet card by default

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -975,6 +975,7 @@ opencomputers {
     # mod's context in an appropriate manner, e.g. using a system firewall.
     blacklist: [
       "127.0.0.0/8"
+      "0.0.0.0/8"
       "10.0.0.0/8"
       "192.168.0.0/16"
       "172.16.0.0/12"


### PR DESCRIPTION
The 0.0.0.0/8 subnet refers to "this network", (c.f. RFC 3330) and in
particular, 0.0.0.0 can be used to refer to the local computer. As such,
it should be blocked by default, as loopback addresses currently are.

This default configuration was relevant to a challenge in the ALLES! CTF
2020 competition, see https://play.allesctf.net/tasks/ALLES!Craft or
https://ctftime.org/event/1091. The challenge involved multiple servers
interconnected with Waterfall as a proxy, to enable server
teleportation. The solution to the challenge was to use an internet card
on one of the servers to connect to 0.0.0.0, bypassing the Waterfall
proxy, and replay or reverse proxy a Minecraft handshake in Lua, which
allowed spoofing as a different user.