### PR TITLE
Cleanup and fixes in OpenOS.

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/cp.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/cp.lua
@@ -19,7 +19,7 @@ if #args < 2 or options.h then
 end
 
 -- clean options for copy (as opposed to move)
-options = 
+options =
 {
   cmd = "cp",
   i = options.i,

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/dmesg.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/dmesg.lua
@@ -28,7 +28,7 @@ pcall(function()
         io.write("  " .. tostring(evt[i]))
       end
     end
-    
+
     io.write("\n")
   until evt[1] == "interrupted"
 end)

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/du.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/du.lua
@@ -69,7 +69,7 @@ local function formatSize(size)
     unit = unit + 1
     size = size / power
   end
-    
+
   return math.floor(size * 10) / 10 .. sizes[unit]
 end
 
@@ -90,7 +90,7 @@ local function visitor(rpath)
       subtotal = subtotal + vtotal
       dirs = dirs + vdirs
     end
-        
+
     if dirs == 0 then -- no child dirs
       if not bSummary then
         printSize(subtotal, rpath)
@@ -113,7 +113,7 @@ for i,arg in ipairs(args) do
   else
     if fs.isDirectory(path) then
       local total = visitor(arg)
-                
+
       if bSummary then
         printSize(total, arg)
       end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/edit.lua
@@ -485,7 +485,7 @@ local function uncut()
   for _, line in ipairs(cutBuffer) do
     insert(line)
     enter()
-  end 
+  end
 end
 
 -------------------------------------------------------------------------------

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/find.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/find.lua
@@ -2,11 +2,11 @@ local shell = require("shell")
 local fs = require("filesystem")
 local text = require("text")
 
-local USAGE = 
+local USAGE =
 [===[Usage: find [path] [--type=[dfs]] [--[i]name=EXPR]
   --path  if not specified, path is assumed to be current working directory
   --type  returns results of a given type, d:directory, f:file, and s:symlinks
-  --name  specify the file name pattern. Use quote to include *. iname is 
+  --name  specify the file name pattern. Use quote to include *. iname is
           case insensitive
   --help  display this help and exit]===]
 
@@ -74,31 +74,31 @@ if options.iname or options.name then
   -- prefix any * with . for gnu find glob matching
   fileNamePattern = text.escapeMagic(fileNamePattern)
   fileNamePattern = fileNamePattern:gsub("%%%*", ".*")
-end  
+end
 
 local function isValidType(spath)
   if not fs.exists(spath) then
     return false
   end
-    
+
   if fileNamePattern:len() > 0 then
     local fileName = spath:gsub('.*/','')
-        
+
     if fileName:len() == 0 then
       return false
     end
-        
+
     local caseFileName = fileName
-        
+
     if not bCaseSensitive then
       caseFileName = caseFileName:lower()
     end
-        
+
     local s, e = caseFileName:find(fileNamePattern)
     if not s or not e then
       return false
     end
-        
+
     if s ~= 1 or e ~= caseFileName:len() then
       return false
     end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/flash.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/flash.lua
@@ -19,7 +19,7 @@ end
 
 local function readRom()
   local eeprom = component.eeprom
-  fileName = shell.resolve(args[1])
+  local fileName = shell.resolve(args[1])
   if not options.q then
     if fs.exists(fileName) then
       io.write("Are you sure you want to overwrite " .. fileName .. "?\n")

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/head.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/head.lua
@@ -1,5 +1,4 @@
 local shell = require("shell")
-local fs = require("filesystem")
 
 local args, options = shell.parse(...)
 local error_code = 0
@@ -26,11 +25,6 @@ quiet = quiet[1] or quiet[2] or quiet[3]
 local verbose = {pop('v'), pop('verbose')}
 verbose = verbose[1] or verbose[2]
 local help = pop('help')
-local invalid_key = next(options)
-
-if bytes and lines then
-  invalid_key = 'bytes and lines both specified'
-end
 
 if help or next(options) then
   local invalid_key = next(options)
@@ -111,7 +105,7 @@ end
 
 for i=1,#args do
   local arg = args[i]
-  local file
+  local file, reason
   if arg == '-' then
     arg = 'standard input'
     file = io.stdin

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/label.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/label.lua
@@ -28,7 +28,7 @@ if options.a then
     end
   end
 else
-  proxy, reason = devfs.getDevice(args[1])
+  proxy, reason = devfs.getDevice(filter)
 end
 
 if not proxy then
@@ -45,5 +45,5 @@ if #args < 2 then
     return 1
   end
 else
-  devfs.setDeviceLabel(proxy, args[2])
+  devfs.setDeviceLabel(proxy, label)
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/ln.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/ln.lua
@@ -1,4 +1,3 @@
-local component = require("component")
 local fs = require("filesystem")
 local shell = require("shell")
 

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/mktmp.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/mktmp.lua
@@ -52,7 +52,7 @@ local prefix = args[1] or os.getenv("TMPDIR") .. '/'
 if not fs.exists(prefix) then
   io.stderr:write(
     string.format(
-      "cannot create tmp file or directory at %s, it does not exist\n", 
+      "cannot create tmp file or directory at %s, it does not exist\n",
       prefix))
   return 1
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/mount.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/mount.lua
@@ -31,7 +31,7 @@ end
 local function print_mounts()
   -- for each mount
   local mounts = {}
-  
+
   for proxy,path in fs.mounts() do
     local device = {}
 
@@ -56,7 +56,7 @@ local function print_mounts()
     for _,device in ipairs(dev_mounts) do
       local rw_ro = "(" .. device.rw_ro .. ")"
       local fs_label = "\"" .. device.fs_label .. "\""
-            
+
       io.write(string.format("%-8s on %-10s %s %s\n",
         dev_path:sub(1,8),
         device.mount_path,

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/mv.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/mv.lua
@@ -17,7 +17,7 @@ if #args < 2 or options.h then
 end
 
 -- clean options for move (as opposed to copy)
-options = 
+options =
 {
   cmd = "mv",
   f = options.f,

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/pastebin.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/pastebin.lua
@@ -43,19 +43,19 @@ local function get(pasteId, filename)
 end
 
 -- This makes a string safe for being used in a URL.
-function encode(code)
+local function encode(code)
   if code then
     code = string.gsub(code, "([^%w ])", function (c)
       return string.format("%%%02X", string.byte(c))
     end)
     code = string.gsub(code, " ", "+")
   end
-  return code 
+  return code
 end
 
 -- This stores the program in a temporary file, which it will
 -- delete after the program was executed.
-function run(pasteId, ...)
+local function run(pasteId, ...)
   local tmpFile = os.tmpname()
   get(pasteId, tmpFile)
   io.write("Running...\n")
@@ -68,7 +68,7 @@ function run(pasteId, ...)
 end
 
 -- Uploads the specified file as a new paste to pastebin.com.
-function put(path)
+local function put(path)
   local config = {}
   local configFile = loadfile("/etc/pastebin.conf", "t", config)
   if configFile then
@@ -90,7 +90,7 @@ function put(path)
 
   io.write("Uploading to pastebin.com... ")
   local result, response = pcall(internet.request,
-        "https://pastebin.com/api/api_post.php", 
+        "https://pastebin.com/api/api_post.php",
         "api_option=paste&" ..
         "api_dev_key=" .. config.key .. "&" ..
         "api_paste_format=lua&" ..

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/ps.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/ps.lua
@@ -1,7 +1,6 @@
 local process = require("process")
 local unicode = require("unicode")
 local event = require("event")
-local thread = require("thread")
 local event_mt = getmetatable(event.handlers)
 
 -- WARNING this code does not use official kernel API and is likely to change

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/rc.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/rc.lua
@@ -21,7 +21,7 @@ local function saveConfig(conf)
   for key, value in pairs(conf) do
     file:write(tostring(key) .. " = " .. require("serialization").serialize(value) .. "\n")
   end
-  
+
   file:close()
   return true
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/rm.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/rm.lua
@@ -72,6 +72,8 @@ local function confirm()
   return r == 'y' or r == 'yes'
 end
 
+local remove
+
 local function remove_all(parent)
   if parent == nil or not _dir(parent) or _empty(parent) then
     return true
@@ -93,7 +95,7 @@ local function remove_all(parent)
   return all_ok
 end
 
-local function remove(meta)
+remove = function(meta)
   if not remove_all(meta) then
     return false
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/rmdir.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/rmdir.lua
@@ -59,7 +59,7 @@ local function remove(path, ...)
     return ec_bump()
   else
     local list, reason = fs.list(rpath)
-        
+
     if not list then
       io.stderr:write(tostring(reason)..'\n')
       return ec_bump()
@@ -88,7 +88,7 @@ for _,path in ipairs(args) do
 
   local segments = {}
   if options.p and path:len() > 1 and path:find('/') then
-    chain = text.split(path, {'/'}, true)
+    local chain = text.split(path, {'/'}, true)
     local prefix = ''
     for _,e in ipairs(chain) do
       table.insert(segments, 1, prefix .. e)

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/set.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/set.lua
@@ -5,7 +5,7 @@ if #args < 1 then
     io.write(k .. "='" .. string.gsub(v, "'", [['"'"']]) .. "'\n")
   end
 else
-  local count = 0 
+  local count = 0
   for _, expr in ipairs(args) do
     local e = expr:find('=')
     if e then

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/sleep.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/sleep.lua
@@ -1,5 +1,4 @@
 local shell = require("shell")
-local tty = require("tty")
 local args, options = shell.parse(...)
 
 if options.help then

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/source.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/source.lua
@@ -19,13 +19,13 @@ end
 
 local lines = file:lines()
 
-while true do  
+while true do
   local line = lines()
   if not line then
     break
   end
   local current_data = process.info().data
-  
+
   local source_proc = process.load((assert(os.getenv("SHELL"), "no $SHELL set")))
   local source_data = process.list[source_proc].data
   source_data.aliases = current_data.aliases -- hacks to propogate sub shell env changes

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/time.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/time.lua
@@ -4,7 +4,7 @@ local sh = require('sh')
 local real_before, cpu_before = computer.uptime(), os.clock()
 local cmd_result = 0
 if ... then
-  sh.execute(nil, ...) 
+  sh.execute(nil, ...)
   cmd_result = sh.getLastExitCode()
 end
 local real_after, cpu_after = computer.uptime(), os.clock()

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/wget.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/wget.lua
@@ -95,7 +95,7 @@ if result then
   if not options.q then
     io.write("success.\n")
   end
-  
+
   if f then
     f:close()
   end

--- a/src/main/resources/assets/opencomputers/loot/openos/bin/which.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/which.lua
@@ -8,7 +8,7 @@ end
 
 for i = 1, #args do
   local result, reason = shell.resolve(args[i], "lua")
-  
+
   if not result then
     result = shell.getAlias(args[i])
     if result then

--- a/src/main/resources/assets/opencomputers/loot/openos/boot/01_process.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/01_process.lua
@@ -32,7 +32,7 @@ intercept_load = function(source, label, mode, env)
       return prev_load(_source, _label, _mode, _env or env)
     end}, {
       __index = env,
-      __pairs = function(...) return pairs(env, ...) end,
+      __pairs = function() return pairs(env) end,
       __newindex = function(_, key, value) env[key] = value end,
   })
   return kernel_load(source, label, mode, e or process.info().env)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/colors.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/colors.lua
@@ -1,5 +1,5 @@
 local colors = {
-  [0] = "white",  
+  [0] = "white",
   [1] = "orange",
   [2] = "magenta",
   [3] = "lightblue",

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/cursor.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/cursor.lua
@@ -80,7 +80,7 @@ function core_cursor.vertical:echo(arg, num)
     return
   end
   local out = io.stdin.stream
-  
+
   if not gpu then return end
   win.nowrap = self.nowrap
   if arg == "" then -- special scroll request
@@ -215,7 +215,7 @@ function core_cursor.read(cursor)
   if #last > 0 then
     cursor:handle("clipboard", last)
   end
-  
+
   -- address checks
   local address_check =
   {

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/devfs/02_utils.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/devfs/02_utils.lua
@@ -1,6 +1,6 @@
 return
 {
-  eeprom = 
+  eeprom =
   {
     link = "components/by-type/eeprom/0/contents",
     isAvailable = function()

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_cursor.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_cursor.lua
@@ -38,7 +38,7 @@ function core_cursor.tab(cursor)
   end
 
   local cache = cursor.cache
-  
+
   if #cache == 1 and cache.i == 0 then
     -- there was only one solution, and the user is asking for the next
     cursor.cache = hints(cache[1], cursor.index + 1)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_sh.lua
@@ -139,8 +139,8 @@ function sh.internal.glob(eword)
 
   local segments = text.split(glob_pattern, {"/"}, true)
   local hiddens = tx.foreach(segments,function(e)return e:match("^%%%.")==nil end)
-  local function is_visible(s,i) 
-    return not hiddens[i] or s:match("^%.") == nil 
+  local function is_visible(s,i)
+    return not hiddens[i] or s:match("^%.") == nil
   end
 
   local function magical(s)
@@ -184,7 +184,7 @@ function sh.internal.glob(eword)
     relative_separator = "/"
   end
   return paths
-end 
+end
 
 function sh.getMatchingPrograms(baseName)
   if not baseName or baseName == "" then return {} end
@@ -205,7 +205,7 @@ function sh.getMatchingPrograms(baseName)
     end
   end
   return result
-end 
+end
 
 function sh.getMatchingFiles(partial_path)
   -- name: text of the partial file name being expanded
@@ -239,7 +239,7 @@ function sh.getMatchingFiles(partial_path)
     result[1] = result[1] .. "/"
   end
   return result
-end 
+end
 
 function sh.internal.hintHandlerSplit(line)
   -- I do not plan on having text tokenizer parse error on
@@ -293,7 +293,7 @@ function sh.internal.hintHandlerSplit(line)
   else
     return prefix, nil, normal
   end
-end 
+end
 
 function sh.internal.hintHandlerImpl(full_line, cursor)
   -- line: text preceding the cursor: we want to hint this part (expand it)
@@ -333,8 +333,8 @@ function sh.internal.hintHandlerImpl(full_line, cursor)
   local resultSuffix = suffix
   if #result > 0 and unicode.sub(result[1], -1) ~= "/" and
      not suffix:sub(1,1):find('%s') and
-     #result == 1 or searchInPath then 
-    resultSuffix  = " " .. resultSuffix 
+     #result == 1 or searchInPath then
+    resultSuffix  = " " .. resultSuffix
   end
 
   table.sort(result)
@@ -343,7 +343,7 @@ function sh.internal.hintHandlerImpl(full_line, cursor)
     result[i] = prev .. result[i] .. resultSuffix
   end
   return result
-end 
+end
 
 -- verifies that no pipes are doubled up nor at the start nor end of words
 function sh.internal.hasValidPiping(words, pipes)
@@ -358,7 +358,7 @@ function sh.internal.hasValidPiping(words, pipes)
   pipes = pipes or tx.sub(text.syntax, semi_split + 1)
 
   local state = "" -- cannot start on a pipe
-  
+
   for w=1,#words do
     local word = words[w]
     for p=1,#word do
@@ -459,7 +459,7 @@ function sh.internal.splitStatements(words, semicolon)
   checkArg(1, words, "table")
   checkArg(2, semicolon, "string", "nil")
   semicolon = semicolon or ";"
-  
+
   return tx.partition(words, function(g, i)
     if isWordOf(g, {semicolon}) then
       return i, i
@@ -482,7 +482,7 @@ end
 function sh.internal.groupChains(s)
   checkArg(1,s,"table")
   return tx.partition(s,function(w)return isWordOf(w,{"&&","||"})end)
-end 
+end
 
 function sh.internal.remove_negation(chain)
   if isWordOf(chain[1], {"!"}) then

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_text.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_text.lua
@@ -63,7 +63,7 @@ function text.split(input, delimiters, dropDelims, di)
       i=add(next, i, di+1, 1, #next)
     end
   end
-  
+
   return result
 end
 

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_transforms.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_transforms.lua
@@ -13,7 +13,7 @@ function lib.sub(tbl,f,l)
     r[#r+1]=tbl[i]
   end
   return r
-end 
+end
 
 -- Returns a list of subsets of tbl where partitioner acts as a delimiter.
 function lib.partition(tbl,partitioner,dropEnds,f,l)
@@ -64,7 +64,7 @@ function lib.partition(tbl,partitioner,dropEnds,f,l)
   end
 
   return result
-end 
+end
 
 -- calls callback(e,i,tbl) for each ith element e in table tbl from first
 function lib.foreach(tbl,c,f,l)
@@ -106,4 +106,4 @@ function lib.at(tbl, index)
     current_index = current_index + 1
   end
   return nil, current_index - 1 -- went one too far
-end 
+end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/devfs.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/devfs.lua
@@ -182,7 +182,7 @@ end
 
 function api.proxy.list(path)
   local result = {}
-  for name in pairs(dynamic_list(path, false, false)) do
+  for name in pairs(dynamic_list(path, false)) do
     table.insert(result, name)
   end
   return result

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/filesystem.lua
@@ -213,7 +213,7 @@ end
 function filesystem.exists(path)
   if not filesystem.realPath(filesystem.path(path)) then
     return false
-  end 
+  end
   local node, rest, vnode, vrest = findNode(path)
   if not vrest or vnode.links[vrest] then -- virtual directory or symbolic link
     return true

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/internet.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/internet.lua
@@ -1,6 +1,5 @@
 local buffer = require("buffer")
 local component = require("component")
-local event = require("event")
 
 local internet = {}
 

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/keyboard.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/keyboard.lua
@@ -26,8 +26,6 @@ keyboard.keys = {
   tab             = 0x0F,
   up              = 0xC8,
   ["end"]         = 0xCF,
-  enter           = 0x1C,
-  tab             = 0x0F,
   numpadenter     = 0x9C,
 }
 

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/pipe.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/pipe.lua
@@ -43,7 +43,7 @@ function pipe.createCoroutineStack(root, env, name)
   return pco
 end
 
-local pipe_stream = 
+local pipe_stream =
 {
   continue = function(self, exit)
     local result = table.pack(coroutine.resume(self.next))

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/sh.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/sh.lua
@@ -185,7 +185,7 @@ function sh.internal.executePipes(pipe_parts, eargs, env)
     commands[#commands + 1] = table.pack(table.remove(args, 1), args, redirects)
   end
 
-  local threads, reason = sh.internal.createThreads(commands, env, {[#commands]=eargs})  
+  local threads, reason = sh.internal.createThreads(commands, env, {[#commands]=eargs})
   if not threads then return false, reason end
   return process.internal.continue(threads[1])
 end

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/term.lua
@@ -95,7 +95,7 @@ local function create_cursor(history, ops)
       pwchar = function(text)
         return text:gsub(".", pwchar_text)
       end
-    end  
+    end
     function cursor:echo(arg, ...)
       if pwchar and type(arg) == "string" and #arg > 0 and not arg:match("^\27") then -- "" is used for scrolling
         arg = pwchar(arg)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/text.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/text.lua
@@ -31,7 +31,7 @@ function text.internal.tokenize(value, options)
   local words, reason = text.internal.words(value, options)
 
   local splitter = text.escapeMagic(custom and table.concat(delimiters) or "<>|;&")
-  if type(words) ~= "table" or 
+  if type(words) ~= "table" or
     #splitter == 0 or
     not value:find("["..splitter.."]") then
     return words, reason

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/thread.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/thread.lua
@@ -308,8 +308,8 @@ do
     handlers_mt.__newindex = function(_, key, value)
       process.info().data.handlers[key] = value
     end
-    handlers_mt.__pairs = function(_, ...)
-      return pairs(process.info().data.handlers, ...)
+    handlers_mt.__pairs = function(_)
+      return pairs(process.info().data.handlers)
     end
     handlers_mt.__call = function(tbl, ...)
       return process.info().data.pull(tbl, ...)

--- a/src/main/resources/assets/opencomputers/loot/openos/lib/tools/transfer.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/tools/transfer.lua
@@ -1,6 +1,5 @@
 local fs = require("filesystem")
 local shell = require("shell")
-local text = require("text")
 local lib = {}
 
 local function perr(ops, format, ...)
@@ -141,7 +140,7 @@ function lib.recurse(fromPath, toPath, options, origin, top)
   if mv and is_mount then
     return false, string.format("cannot move '%s', it is a mount point", fromPath)
   end
-  
+
   if fromIsLink and options.P and not (toExists and same_path and not toIsLink) then
     if toExists and options.n then
       return true

--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/cd
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/cd
@@ -9,13 +9,13 @@ DESCRIPTION
   `cd` allows changing the current working directory, i.e the directory based on which relative paths are resolved.
 
   If no operand is given then HOME environment variable is used.
-  
+
   If the operand is - (just a single dash) then OLDPWD environment variable is used.
-  
+
   Relative path components ./ and ../ may be used to denote the working directory and the parent directory, respectively. An operand starting with ./ is equivalent to PWD environment variable. See examples for illustrations.
-  
+
   Lastly, cd will attempt to change the current directory to the path defined by the operand, reporting errors if any.
-  
+
   If cd is successful, OLDPWD environment variable will also be set to the previous value of PWD (that is the current working directory immediately prior to the call to cd).
 
 ENVIRONMENT VARIABLES

--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/dmesg
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/dmesg
@@ -1,6 +1,6 @@
 NAME
   dmesg - display messages(events)
-    
+
 SYNOPIS
   dmesg [EVENT]...
 

--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/man
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/man
@@ -5,7 +5,7 @@ SYNOPSIS
   man topic
 
 DESCRIPTION
-  `man` is the system's help viewer. Each help topic is normally the name of a program or library. Topics are stored as individual text files in the `/usr/man` folder. Additional help topics can be provided by creating a symbolic link to a file. 
+  `man` is the system's help viewer. Each help topic is normally the name of a program or library. Topics are stored as individual text files in the `/usr/man` folder. Additional help topics can be provided by creating a symbolic link to a file.
 
 EXAMPLES
   man man

--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/mount
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/mount
@@ -8,7 +8,7 @@ SYNOPSIS
   mount --bind PATH PATH
 
 OPTIONS
-  -r, --readonly  mount filesystem readonly 
+  -r, --readonly  mount filesystem readonly
       --bind      mount a bind point (folder to folder)
   -h, --help      print help message
 

--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/rm
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/rm
@@ -16,11 +16,11 @@ OPTIONS
 
   -f, --force
          ignore nonexistent files and arguments, never prompt
-  
+
   -i     prompt before every removal
-  
+
   -I     prompt once before removing more than three files, or when removing recursively; less intrusive than -i, while still giving protection against most mistakes
-  
+
   --one-file-system
          when removing a hierarchy recursively, skip any directory that is on a file system different from that of the corresponding command line argument
 

--- a/src/main/resources/assets/opencomputers/loot/openos/usr/man/rmdir
+++ b/src/main/resources/assets/opencomputers/loot/openos/usr/man/rmdir
@@ -1,6 +1,6 @@
 NAME
   rmdir - remove empty directories
-    
+
 SYNOPIS
   rmdir [DIRECTORY]
 


### PR DESCRIPTION
Various cleanup and minor fixes all over OpenOS, which showed up with the vscode Lua plugin (a great plugin btw).

The changes include:

- Removed all trailing whitespace.
- Made accidental globals local.
- Removed unused locals (including unused requires).
- Removed duplicate `enter` and `tab` from `keyboard.keys` table.
- Removed handling of `...` varargs from pairs, as it only takes a single parameter.
- A fix in `rm.lua`, where `remove` and `remove_all` both call each other, but `remove` is defined after `remove_all`.
- ... and probably a few other things I missed.