### PR TITLE
Fix documentation on redstone orientation

### DIFF
--- a/src/main/resources/assets/opencomputers/doc/en_us/item/redstonecard1.md
+++ b/src/main/resources/assets/opencomputers/doc/en_us/item/redstonecard1.md
@@ -6,4 +6,4 @@ The redstone card allows [computers](../general/computer.md) to read and emit an
 
 If there are any supported mods present that provide bundled redstone facilities, such as RedLogic, Project Red or MineFactory Reloaded; or mods that provide wireless redstone facilities such as WR-CBE and Slimevoid's Wireless mod, a second tier card is available that allows interacting with these systems.
 
-The side provided to the several methods are relative to the orientation of the [computer case](../block/case1.md) / [robot](../block/robot.md) / [rack](../block/rack.md). That means when looking at the front of the computer, `sides.right` is at your left and vice versa.
+The side provided to the several methods are relative to the orientation of the [computer case](../block/case1.md) / [rack](../block/rack.md). That means when looking at the front of the computer, `sides.right` is at your left and vice versa. However, absolute sides are used with a [robot](../block/robot.md), such as `sides.north` or `sides.east`.


### PR DESCRIPTION
By experimentation, robots seem to use absolute sides for redstone output, not relative sides.