### PR TITLE
Fixed OC Block GUIs with Y < 0 for CubicChunks compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ buildscript {
         jcenter()
         maven {
             name = "forge"
-            url = "https://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net/"
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:5.1.+'
     }
 }
 
@@ -17,7 +17,7 @@ plugins {
 }
 
 apply plugin: 'scala'
-apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'maven-publish'
 
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ buildscript {
         jcenter()
         maven {
             name = "forge"
-            url = "https://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net/"
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:5.1.+'
     }
 }
 
@@ -17,7 +17,7 @@ plugins {
 }
 
 apply plugin: 'scala'
-apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'maven-publish'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -77,6 +77,9 @@ configurations {
 }
 
 dependencies {
+
+    minecraft "net.minecraftforge:forge:${config.minecraft.version}-${config.forge.version}"
+
     deobfCompile ("li.cil.tis3d:TIS-3D:MC1.12-${config.tis3d.version}") {
         exclude module: "jei_1.12"
     }

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.12.2
 minecraft.mappings=snapshot_20180704
-forge.version=14.23.5.2778
+forge.version=14.23.5.2860
 
 mod.name=OpenComputers
 mod.group=li.cil.oc

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -309,7 +309,7 @@ opencomputers {
     #   flight capabilities).
     # - Any position that has an adjacent block with a solid face towards the
     #   position is valid (robots can "climb").
-    # Set this to 256 to allow robots to fly whereever, as was the case
+    # Set this to 2147483647 (Int.MaxValue) to allow robots to fly wherever, as was the case
     # before the 1.5 update. Consider using drones for cases where you need
     # unlimited flight capabilities instead!
     limitFlightHeight: 8

--- a/src/main/scala/li/cil/oc/common/GuiType.scala
+++ b/src/main/scala/li/cil/oc/common/GuiType.scala
@@ -50,7 +50,7 @@ object GuiType extends ScalaEnum {
 
   def embedSlot(y: Int, slot: Int) = (y & 0x00FFFFFF) | (slot << 24)
 
-  def extractY(value: Int) = value & 0x00FFFFFF
+  def extractY(value: Int) = value << 8 >> 8
 
-  def extractSlot(value: Int) = (value >>> 24) & 0xFF
+  def extractSlot(value: Int) = value >>> 24
 }

--- a/src/main/scala/li/cil/oc/common/init/Items.scala
+++ b/src/main/scala/li/cil/oc/common/init/Items.scala
@@ -32,7 +32,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.NonNullList
 import net.minecraft.util.ResourceLocation
-import net.minecraftforge.registries.{GameData}
+import net.minecraftforge.registries.GameData
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -492,8 +492,8 @@ object Items extends ItemAPI {
     Recipes.addSubItem(new item.UpgradeLeash(upgrades), Constants.ItemName.LeashUpgrade, "oc:leashUpgrade")
 
     // 1.5.8
-    Recipes.addSubItem(new item.UpgradeHover(upgrades, Tier.One), Constants.ItemName.HoverUpgradeTier1, "oc:hoverUpgrade1")
-    Recipes.addSubItem(new item.UpgradeHover(upgrades, Tier.Two), Constants.ItemName.HoverUpgradeTier2, "oc:hoverUpgrade2")
+    Recipes.addSubItem(new item.UpgradeHover(upgrades, Settings.get.upgradeFlightHeight(Tier.One), Tier.One), Constants.ItemName.HoverUpgradeTier1, "oc:hoverUpgrade1")
+    Recipes.addSubItem(new item.UpgradeHover(upgrades, Settings.get.upgradeFlightHeight(Tier.Two), Tier.Two), Constants.ItemName.HoverUpgradeTier2, "oc:hoverUpgrade2")
 
     // 1.6
     Recipes.addSubItem(new item.UpgradeTrading(upgrades), Constants.ItemName.TradingUpgrade, "oc:tradingUpgrade")

--- a/src/main/scala/li/cil/oc/common/item/UpgradeHover.scala
+++ b/src/main/scala/li/cil/oc/common/item/UpgradeHover.scala
@@ -1,11 +1,9 @@
 package li.cil.oc.common.item
 
-import li.cil.oc.Settings
-
-class UpgradeHover(val parent: Delegator, val tier: Int) extends traits.Delegate with traits.ItemTier {
+class UpgradeHover(val parent: Delegator, val heightLimit: Int, val tier: Int) extends traits.Delegate with traits.ItemTier {
   override val unlocalizedName = super.unlocalizedName + tier
 
   override protected def tooltipName = Option(super.unlocalizedName)
 
-  override protected def tooltipData = Seq(Settings.get.upgradeFlightHeight(tier))
+  override protected def tooltipData = Seq(heightLimit)
 }


### PR DESCRIPTION
Basically, OC encodes the slot you clicked for the Server Rack block in the Y coordinate, that sure works with a bitmask in a restricted positive Y range, but said bitmask fails when negative values are needed, thus i replaced `& 0x00FFFFFF` with a more negative friendly `<< 8 >> 8`