### PR TITLE
Add fluid container item converter

### DIFF
--- a/src/main/scala/li/cil/oc/integration/vanilla/ConverterFluidContainerItem.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ConverterFluidContainerItem.scala
@@ -1,0 +1,37 @@
+package li.cil.oc.integration.vanilla
+
+import java.util
+
+import li.cil.oc.{Settings, api}
+import net.minecraft.item
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fluids
+import net.minecraftforge.fluids.FluidStack
+
+import scala.collection.convert.WrapAsScala._
+
+object ConverterFluidContainerItem extends api.driver.Converter  {
+  override def convert(value: AnyRef, output: util.Map[AnyRef, AnyRef]): Unit =
+    value match {
+      case stack: item.ItemStack => stack.getItem match {
+        case fc: fluids.IFluidContainerItem =>
+          output += "capacity" -> Int.box(fc.getCapacity(stack))
+          val fluidStack  = fc.getFluid(stack)
+          if (fluidStack != null && fluidStack.getFluid != null) {
+            val fluid = fluidStack.getFluid
+            if (Settings.get.insertIdsInConverters)
+              output += "fluid_id" -> Int.box(fluid.getID)
+            output += "amount" -> Int.box(fluidStack.amount)
+            output += "fluid_hasTag" -> Boolean.box(fluidStack.tag != null)
+            if (fluid != null) {
+              output += "fluid_name" -> fluid.getName
+              output += "fluid_label" -> fluid.getLocalizedName(fluidStack)
+            }
+          }
+          else
+            output += "amount" -> Int.box(0)
+        case _ =>
+      }
+      case _ =>
+    }
+}

--- a/src/main/scala/li/cil/oc/integration/vanilla/ConverterFluidTankInfo.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ConverterFluidTankInfo.scala
@@ -8,7 +8,7 @@ import net.minecraftforge.fluids
 import scala.collection.convert.WrapAsScala._
 
 object ConverterFluidTankInfo extends api.driver.Converter {
-  override def convert(value: AnyRef, output: util.Map[AnyRef, AnyRef]) =
+  override def convert(value: AnyRef, output: util.Map[AnyRef, AnyRef]): Unit =
     value match {
       case tankInfo: fluids.FluidTankInfo =>
         output += "capacity" -> Int.box(tankInfo.capacity)

--- a/src/main/scala/li/cil/oc/integration/vanilla/ModVanilla.scala
+++ b/src/main/scala/li/cil/oc/integration/vanilla/ModVanilla.scala
@@ -45,6 +45,7 @@ object ModVanilla extends ModProxy with RedstoneProvider {
 
     Driver.add(ConverterFluidStack)
     Driver.add(ConverterFluidTankInfo)
+    Driver.add(ConverterFluidContainerItem)
     Driver.add(ConverterItemStack)
     Driver.add(ConverterNBT)
     Driver.add(ConverterWorld)


### PR DESCRIPTION
(Volumetric flask, certus tank, universal cell, etc.)
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8807

"fluid_hasTag" key may look dubious, but it corresponds to the ConverterItemStack