### PR TITLE
Fix ls.lua timestamp

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_ls.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/core/full_ls.lua
@@ -310,7 +310,7 @@ local function stat(path, name)
   info.sort_name = info.name:gsub("^%.","")
   info.isLink, info.link = fs.isLink(info.full_path)
   info.size = info.isLink and 0 or fs.size(info.full_path)
-  info.time = fs.lastModified(info.full_path)
+  info.time = fs.lastModified(info.full_path)/1000
   info.fs = fs.get(info.full_path)
   info.ext = info.name:match("(%.[^.]+)$") or ""
   return info


### PR DESCRIPTION
filesystem.lastModified returns timestamp as milliseconds but os.date using it as seconds, so files modification date was shown wrong