### PR TITLE
Fix tablet assigning itself an ID on the client when it should not have one

### DIFF
--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -616,12 +616,14 @@ object Tablet {
     override protected def timeout = 5
 
     def getWeak(stack: ItemStack): Option[TabletWrapper] = {
-      val key = getId(stack)
-      val map = cache.asMap
-      if (map.containsKey(key))
-        Some(map.entrySet.find(entry => entry.getKey == key).get.getValue)
-      else
-        None
+      if (stack.hasTagCompound && stack.getTagCompound.hasKey(Settings.namespace + "tablet")) {
+        val key = getId(stack)
+        val map = cache.asMap
+        if (map.containsKey(key))
+          Some(map.entrySet.find(entry => entry.getKey == key).get.getValue)
+      }
+
+      None
     }
 
     def get(stack: ItemStack): Option[TabletWrapper] = {

--- a/src/main/scala/li/cil/oc/common/item/Tablet.scala
+++ b/src/main/scala/li/cil/oc/common/item/Tablet.scala
@@ -5,7 +5,6 @@ import java.util
 import java.util.UUID
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
-
 import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
 import com.google.common.collect.ImmutableMap
 import li.cil.oc.Constants
@@ -48,6 +47,7 @@ import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.server.integrated.IntegratedServer
 import net.minecraft.util._
 import net.minecraft.world.World
+import net.minecraftforge.common.util.Constants.NBT
 import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.FMLCommonHandler
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -474,7 +474,14 @@ object Tablet {
   // with storing context information for analyzing a block in the singleton.
   var currentlyAnalyzing: Option[(BlockPosition, EnumFacing, Float, Float, Float)] = None
 
-  def getId(stack: ItemStack): String = {
+  def getId(stack: ItemStack): Option[String] = {
+    if (stack.hasTagCompound && stack.getTagCompound.hasKey(Settings.namespace + "tablet", NBT.TAG_STRING)) {
+      Some(stack.getTagCompound.getString(Settings.namespace + "tablet"))
+    }
+    else None
+  }
+
+  def getOrCreateId(stack: ItemStack): String = {
 
     if (!stack.hasTagCompound) {
       stack.setTagCompound(new NBTTagCompound())
@@ -534,7 +541,7 @@ object Tablet {
     private var currentHolder: EntityPlayer = _
 
     def get(stack: ItemStack, holder: EntityPlayer): TabletWrapper = {
-      val id = getId(stack)
+      val id = getOrCreateId(stack)
       cache.synchronized {
         currentStack = stack
         currentHolder = holder
@@ -616,8 +623,8 @@ object Tablet {
     override protected def timeout = 5
 
     def getWeak(stack: ItemStack): Option[TabletWrapper] = {
-      if (stack.hasTagCompound && stack.getTagCompound.hasKey(Settings.namespace + "tablet")) {
-        val key = getId(stack)
+      val key = getId(stack)
+      if (key.nonEmpty) {
         val map = cache.asMap
         if (map.containsKey(key))
           Some(map.entrySet.find(entry => entry.getKey == key).get.getValue)
@@ -627,8 +634,8 @@ object Tablet {
     }
 
     def get(stack: ItemStack): Option[TabletWrapper] = {
-      if (stack.hasTagCompound && stack.getTagCompound.hasKey(Settings.namespace + "tablet")) {
-        val id = stack.getTagCompound.getString(Settings.namespace + "tablet")
+      val id = getId(stack);
+      if (id.nonEmpty) {
         cache.synchronized(Option(cache.getIfPresent(id)))
       }
       else None

--- a/src/main/scala/li/cil/oc/integration/opencomputers/DriverTablet.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/DriverTablet.scala
@@ -20,7 +20,7 @@ object DriverTablet extends Item {
   override def createEnvironment(stack: ItemStack, host: EnvironmentHost) =
     if (host.world != null && host.world.isRemote) null
     else {
-      Tablet.Server.cache.invalidate(Tablet.getId(stack))
+      Tablet.Server.cache.invalidate(Tablet.getOrCreateId(stack))
       val data = new TabletData(stack)
       data.items.collect {
         case fs if !fs.isEmpty && DriverFileSystem.worksWith(fs) => fs


### PR DESCRIPTION
Fixes #3552 

The tablet in 1.12 has an [extra cache getter](https://github.com/MightyPirates/OpenComputers/blob/master-MC1.12/src/main/scala/li/cil/oc/common/item/Tablet.scala#L618) that doesn't check if the tablet has an ID, which causes it to generate one if it is missing. Any items in the creative menu only exist on the client, so the tablet then thinks there is a tablet on the server with the same ID when there is not.