### PR TITLE
Fix/1.12 build

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/DataCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/DataCard.scala
@@ -30,7 +30,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream
 
 import scala.collection.convert.WrapAsJava._
 
-abstract class DataCard extends prefab.ManagedEnvironment with DeviceInfo {
+abstract class DataCard extends prefab.AbstractManagedEnvironment with DeviceInfo {
   override val node = Network.newNode(this, Visibility.Neighbors).
     withComponent("data", Visibility.Neighbors).
     withConnector().


### PR DESCRIPTION
In betwen OC for 1.7 and OC for 1.12 it seems that the class
li.cil.oc.api.prefab.ManagedEnvironment was renamed to
li.cil.oc.api.prefab.AbstractManagedEnvironment -- This fixes the
DataCard class to use the new prefab class name