### PR TITLE
theoretically fix #3580

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/thread.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/thread.lua
@@ -265,6 +265,7 @@ function thread.create(fp, ...)
     local old_status = t:status()
     mt.__status = "dead"
     process.removeHandle(t, mt.attached)
+    process.removeHandle(mt.process, t)
     if old_status ~= "dead" then
       event.push("thread_exit")
     end


### PR DESCRIPTION
I dug around a bit in the OpenOS source code and figured out that the apparent issue in #3580 is that the dead thread never gets removed from its parent process.  This extra line of code should fix that.

I have *not* extensively tested this.  It may well subtly break something.