### PR TITLE
Backport text_input event to 1.7.10

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/Keyboard.scala
+++ b/src/main/scala/li/cil/oc/server/component/Keyboard.scala
@@ -70,9 +70,11 @@ class Keyboard(val host: EnvironmentHost) extends prefab.ManagedEnvironment with
           pressedKeys.getOrElseUpdate(p, mutable.Map.empty[Integer, Character]) += code -> char
           if (Settings.get.inputUsername) {
             signal(p, "key_down", char, code, p.getCommandSenderName)
+            signal(p, "text_input", char.toString, p.getCommandSenderName)
           }
           else {
             signal(p, "key_down", char, code)
+            signal(p, "text_input", char.toString)
           }
         }
       case Array(p: EntityPlayer, char: Character, code: Integer) if message.name == "keyboard.keyUp" =>


### PR DESCRIPTION
This is the same patch suggested by asie here: https://github.com/MightyPirates/OpenComputers/pull/3572#discussion_r1014625140

I tested that it compiles and works as expected with basic alphabet keys in 1.7.10.