### PR TITLE
Update FancyGradle repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
         maven {
             name 'FancyGradle'
-            url 'https://gitlab.com/api/v4/projects/26758973/packages/maven'
+            url 'https://maven.gofancy.wtf/releases'
         }
     }
     dependencies {


### PR DESCRIPTION
The FancyGradle maven repo was moved in https://gitlab.com/gofancy/fancygradle/-/commit/b1be3e3f, but things only started breaking when the LegacyDev fork repo moved in https://gitlab.com/gofancy/fancygradle/-/commit/9f5b236b.