### PR TITLE
Improved documentation for network floppy

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/network/data/usr/man/arp
+++ b/src/main/resources/assets/opencomputers/loot/network/data/usr/man/arp
@@ -1,0 +1,8 @@
+NAME
+  arp - Inspect local address resolution
+  
+SYNOPSIS
+  arp
+  
+DESCRIPTION
+  Displays the address of each network interface

--- a/src/main/resources/assets/opencomputers/loot/network/data/usr/man/ifconfig
+++ b/src/main/resources/assets/opencomputers/loot/network/data/usr/man/ifconfig
@@ -12,5 +12,5 @@ EXAMPLES
     Output network status information
     
   ifconfig bind [address]
-    Binds addnitional address to this device. Address should match [A-Za-z0-9%-]+ and be max 64 characters length
+    Binds additional address to this device. Address should match [A-Za-z0-9%-]+ and be max 64 characters length
 

--- a/src/main/resources/assets/opencomputers/loot/network/data/usr/man/nc
+++ b/src/main/resources/assets/opencomputers/loot/network/data/usr/man/nc
@@ -1,0 +1,15 @@
+NAME
+  nc - Connect STDIN and STDOUT to the network
+  
+SYNOPSIS
+  nc [-l] port [addr]
+  
+DESCRIPTION
+  Connect STDIN and STDOUT to a network socket so that data can be received from and sent to that socket via STDIN and STDOUT
+  
+EXAMPLES
+  nc -l 1337
+    Open a socket on port 1337. If another program connects, it can receive from STDIN and send to STDOUT.
+    
+  nc 1337 host1
+    Connect to an open socket at address 'host1' on port 1337. The running program can send to STDOUT and receive from STDIN

--- a/src/main/resources/assets/opencomputers/loot/network/data/usr/man/route
+++ b/src/main/resources/assets/opencomputers/loot/network/data/usr/man/route
@@ -1,0 +1,8 @@
+NAME
+  route - Show routing information
+  
+SYNOPSIS
+  route
+  
+DESCRIPTION
+  Displays the contents of the routing table


### PR DESCRIPTION
Adds man pages for the `route`, `arp` and `nc` commands on the network floppy disk. Also fixes a small typo in the man page for `ifconfig`