### PR TITLE
Add ability to robots to obtain nearby experience orbs

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1652,7 +1652,7 @@ opencomputers {
 
     # This setting assigns the budget call cost to invoke bitblt to write vram
     # to a screen. Video ram can bitblit to a screen which can cause real life
-    # network laod the defaults settings put bitblit network impact close to gpu.set
+    # network load the defaults settings put bitblit network impact close to gpu.set
     # Increase these values to throttle bitblt more. The cost tier N is bitbltCost * 2^(tier)
     # default is .5, which gives: .5, 1, 4
     bitbltCost: 0.5

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -412,6 +412,9 @@ opencomputers {
       # two real experience points, redstone is worth 5.
       oreXpRate: 4.0
 
+      # This determines how much experience a robot gets for each suck
+      suckXpRate: 1.0
+
       # This is the amount of additional energy that fits into a robots
       # internal buffer for each level it gains. So with the default values,
       # at maximum level (30) a robot will have an internal buffer size of
@@ -1399,6 +1402,10 @@ opencomputers {
     # The maximum range between the drone/robot and a villager for a trade to
     # be performed by the trading upgrade
     tradingRange: 8.0
+
+    # The maximum range between the drone/robot and a experience orb for a suck to
+    # be performed by the experience upgrade
+    suckExperienceRange: 8.0
 
     # Radius the MFU is able to operate in
     mfuRange: 3

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1006,6 +1006,10 @@ opencomputers {
       "allow default"
     ]
 
+    whitelist: []
+
+    blacklist: []
+
     # The time in seconds to wait for a response to a request before timing
     # out and returning an error message. If this is zero (the default) the
     # request will never time out.

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -412,7 +412,7 @@ opencomputers {
       # two real experience points, redstone is worth 5.
       oreXpRate: 4.0
 
-      # This determines how much experience a robot gets for each suck
+      # This determines how much experience a robot gets for each suck.
       suckXpRate: 1.0
 
       # This is the amount of additional energy that fits into a robots
@@ -1405,7 +1405,7 @@ opencomputers {
 
     # The maximum range between the drone/robot and a experience orb for a suck to
     # be performed by the experience upgrade
-    suckExperienceRange: 8.0
+    suckXpRange: 8.0
 
     # Radius the MFU is able to operate in
     mfuRange: 3

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -388,7 +388,7 @@ class Settings(val config: Config) {
   val serverRackSwitchTier = (config.getInt("misc.serverRackSwitchTier") - 1) max Tier.None min Tier.Three
   val redstoneDelay = config.getDouble("misc.redstoneDelay") max 0
   val tradingRange = config.getDouble("misc.tradingRange") max 0
-  val suckExperienceRange = config.getDouble("misc.suckExperienceRange") max 0
+  val suckXpRange = config.getDouble("misc.suckXpRange") max 0
   val mfuRange = config.getInt("misc.mfuRange") max 0 min 128
 
   // ----------------------------------------------------------------------- //

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -124,6 +124,7 @@ class Settings(val config: Config) {
   val robotActionXp = config.getDouble("robot.xp.actionXp") max 0
   val robotExhaustionXpRate = config.getDouble("robot.xp.exhaustionXpRate") max 0
   val robotOreXpRate = config.getDouble("robot.xp.oreXpRate") max 0
+  val robotSuckXpRate = config.getDouble("robot.xp.suckXpRate") max 0
   val bufferPerLevel = config.getDouble("robot.xp.bufferPerLevel") max 0
   val toolEfficiencyPerLevel = config.getDouble("robot.xp.toolEfficiencyPerLevel") max 0
   val harvestSpeedBoostPerLevel = config.getDouble("robot.xp.harvestSpeedBoostPerLevel") max 0
@@ -387,6 +388,7 @@ class Settings(val config: Config) {
   val serverRackSwitchTier = (config.getInt("misc.serverRackSwitchTier") - 1) max Tier.None min Tier.Three
   val redstoneDelay = config.getDouble("misc.redstoneDelay") max 0
   val tradingRange = config.getDouble("misc.tradingRange") max 0
+  val suckExperienceRange = config.getDouble("misc.suckExperienceRange") max 0
   val mfuRange = config.getInt("misc.mfuRange") max 0 min 128
 
   // ----------------------------------------------------------------------- //

--- a/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
@@ -113,7 +113,7 @@ class UpgradeExperience(val host: EnvironmentHost with internal.Agent) extends A
   @Callback(doc = """function():number -- suck experience from nearby. return the amount of sucked experience""")
   def suck(context: Context, args: Arguments): Array[AnyRef] = {
     val blockPos = host.player().getPosition
-    val maxRange = Settings.get.suckExperienceRange
+    val maxRange = Settings.get.suckXpRange
     var gained = 0D
 
     val alignedBB = new AxisAlignedBB(blockPos, new BlockPos(blockPos.getX + maxRange, blockPos.getY + maxRange, blockPos.getZ + maxRange))

--- a/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
@@ -1,24 +1,5 @@
 package li.cil.oc.server.component
 
-import cofh.core.util.ArrayHashList
-import com.google.common.collect.{ForwardingList, ImmutableList}
-import com.sun.corba.se.spi.ior.{IOR, IORTemplate, IORTemplateList, TaggedProfileTemplate}
-import com.sun.javafx.collections.SortableList
-import com.sun.org.apache.xerces.internal.xs.datatypes.{ByteList, ObjectList}
-import com.sun.org.apache.xerces.internal.xs.{LSInputList, ShortList, StringList, XSNamespaceItemList, XSObjectList}
-import com.typesafe.config.ConfigList
-import gnu.trove.decorator.{TByteListDecorator, TCharListDecorator, TDoubleListDecorator, TFloatListDecorator, TIntListDecorator, TLongListDecorator, TShortListDecorator}
-import it.unimi.dsi.fastutil.booleans.BooleanList
-import it.unimi.dsi.fastutil.bytes.ByteList
-import it.unimi.dsi.fastutil.chars.CharList
-import it.unimi.dsi.fastutil.doubles.DoubleList
-import it.unimi.dsi.fastutil.floats.FloatList
-import it.unimi.dsi.fastutil.ints.IntList
-import it.unimi.dsi.fastutil.longs.LongList
-import it.unimi.dsi.fastutil.objects.{ObjectList, ReferenceList}
-import it.unimi.dsi.fastutil.shorts.ShortList
-import javafx.collections.ObservableList
-
 import java.util
 import li.cil.oc.Constants
 import li.cil.oc.api.driver.DeviceInfo.DeviceAttribute
@@ -34,15 +15,11 @@ import li.cil.oc.api.machine.Context
 import li.cil.oc.api.network.Visibility
 import li.cil.oc.api.prefab.AbstractManagedEnvironment
 import li.cil.oc.util.{BlockPosition, UpgradeExperience}
-import mcp.mobius.waila.api.ITaggedList
 import net.minecraft.enchantment.EnchantmentHelper
 import net.minecraft.entity.item.EntityXPOrb
 import net.minecraft.init.Items
 import net.minecraft.nbt.NBTTagCompound
-import net.minecraft.util.math.{AxisAlignedBB, BlockPos}
-import sun.awt.util.{IdentityArrayList, IdentityLinkedList}
 
-import java.util.concurrent.CopyOnWriteArrayList
 import scala.collection.convert.WrapAsJava._
 import scala.collection.convert.WrapAsScala._
 

--- a/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
@@ -1,5 +1,24 @@
 package li.cil.oc.server.component
 
+import cofh.core.util.ArrayHashList
+import com.google.common.collect.{ForwardingList, ImmutableList}
+import com.sun.corba.se.spi.ior.{IOR, IORTemplate, IORTemplateList, TaggedProfileTemplate}
+import com.sun.javafx.collections.SortableList
+import com.sun.org.apache.xerces.internal.xs.datatypes.{ByteList, ObjectList}
+import com.sun.org.apache.xerces.internal.xs.{LSInputList, ShortList, StringList, XSNamespaceItemList, XSObjectList}
+import com.typesafe.config.ConfigList
+import gnu.trove.decorator.{TByteListDecorator, TCharListDecorator, TDoubleListDecorator, TFloatListDecorator, TIntListDecorator, TLongListDecorator, TShortListDecorator}
+import it.unimi.dsi.fastutil.booleans.BooleanList
+import it.unimi.dsi.fastutil.bytes.ByteList
+import it.unimi.dsi.fastutil.chars.CharList
+import it.unimi.dsi.fastutil.doubles.DoubleList
+import it.unimi.dsi.fastutil.floats.FloatList
+import it.unimi.dsi.fastutil.ints.IntList
+import it.unimi.dsi.fastutil.longs.LongList
+import it.unimi.dsi.fastutil.objects.{ObjectList, ReferenceList}
+import it.unimi.dsi.fastutil.shorts.ShortList
+import javafx.collections.ObservableList
+
 import java.util
 import li.cil.oc.Constants
 import li.cil.oc.api.driver.DeviceInfo.DeviceAttribute
@@ -14,17 +33,20 @@ import li.cil.oc.api.machine.Callback
 import li.cil.oc.api.machine.Context
 import li.cil.oc.api.network.Visibility
 import li.cil.oc.api.prefab.AbstractManagedEnvironment
-import li.cil.oc.util.UpgradeExperience
+import li.cil.oc.util.{BlockPosition, UpgradeExperience}
+import mcp.mobius.waila.api.ITaggedList
 import net.minecraft.enchantment.EnchantmentHelper
 import net.minecraft.entity.item.EntityXPOrb
 import net.minecraft.init.Items
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.math.{AxisAlignedBB, BlockPos}
+import sun.awt.util.{IdentityArrayList, IdentityLinkedList}
 
+import java.util.concurrent.CopyOnWriteArrayList
 import scala.collection.convert.WrapAsJava._
 import scala.collection.convert.WrapAsScala._
 
-class UpgradeExperience(val host: EnvironmentHost with internal.Agent) extends AbstractManagedEnvironment with DeviceInfo {
+class UpgradeExperience(val host: EnvironmentHost with internal.Agent) extends AbstractManagedEnvironment with traits.WorldAware with DeviceInfo {
   final val MaxLevel = 30
 
   override val node = api.Network.newNode(this, Visibility.Network).
@@ -41,6 +63,8 @@ class UpgradeExperience(val host: EnvironmentHost with internal.Agent) extends A
   )
 
   override def getDeviceInfo: util.Map[String, String] = deviceInfo
+
+  override def position: BlockPosition = BlockPosition(host)
 
   var experience = 0.0
 
@@ -112,24 +136,23 @@ class UpgradeExperience(val host: EnvironmentHost with internal.Agent) extends A
 
   @Callback(doc = """function():number -- suck experience from nearby. return the amount of sucked experience""")
   def suck(context: Context, args: Arguments): Array[AnyRef] = {
-    val blockPos = host.player().getPosition
+    val nearBounds = position.bounds
+    val farBounds = nearBounds.offset(Settings.get.suckXpRange, Settings.get.suckXpRange, Settings.get.suckXpRange)
+    val bounds = nearBounds.union(farBounds)
     var gained = 0D
+    entitiesInBounds[EntityXPOrb](classOf[EntityXPOrb], bounds).foreach(orb => {
 
-    val alignedBB = new AxisAlignedBB(blockPos, new BlockPos(blockPos.getX + Settings.get.suckXpRange, blockPos.getY + Settings.get.suckXpRange, blockPos.getZ + Settings.get.suckXpRange))
-    val orbs = host.world().getEntitiesWithinAABB(classOf[EntityXPOrb], alignedBB)
-
-    orbs.foreach( orb =>
       if (!orb.isDead && orb.xpValue > 0) {
         val copy = experience.toDouble
         addExperience(orb.xpValue * Settings.get.robotSuckXpRate)
         val added = (experience.toDouble - copy) / Settings.get.robotSuckXpRate
         gained += added
         orb.xpValue = (orb.xpValue - added.toInt)
-        if(orb.xpValue <= 0){
+        if (orb.xpValue <= 0) {
           orb.setDead()
         }
       }
-    )
+    })
     result(gained)
   }
 

--- a/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeExperience.scala
@@ -113,10 +113,9 @@ class UpgradeExperience(val host: EnvironmentHost with internal.Agent) extends A
   @Callback(doc = """function():number -- suck experience from nearby. return the amount of sucked experience""")
   def suck(context: Context, args: Arguments): Array[AnyRef] = {
     val blockPos = host.player().getPosition
-    val maxRange = Settings.get.suckXpRange
     var gained = 0D
 
-    val alignedBB = new AxisAlignedBB(blockPos, new BlockPos(blockPos.getX + maxRange, blockPos.getY + maxRange, blockPos.getZ + maxRange))
+    val alignedBB = new AxisAlignedBB(blockPos, new BlockPos(blockPos.getX + Settings.get.suckXpRange, blockPos.getY + Settings.get.suckXpRange, blockPos.getZ + Settings.get.suckXpRange))
     val orbs = host.world().getEntitiesWithinAABB(classOf[EntityXPOrb], alignedBB)
 
     orbs.foreach( orb =>


### PR DESCRIPTION
Temporary fix #3289

Existing bug: The format of settings.conf is wrong and cannot be parsed correctly, which will cause a crash.

A temporary fix has been made to this bug. Looks like a past patch oversight caused the crash, so it needs to be reviewed