### PR TITLE
Fix infinite leash

### DIFF
--- a/src/main/scala/li/cil/oc/integration/opencomputers/DriverUpgradeLeash.scala
+++ b/src/main/scala/li/cil/oc/integration/opencomputers/DriverUpgradeLeash.scala
@@ -1,13 +1,12 @@
 package li.cil.oc.integration.opencomputers
 
-import li.cil.oc.Constants
-import li.cil.oc.api
 import li.cil.oc.api.driver.EnvironmentProvider
 import li.cil.oc.api.driver.item.HostAware
+import li.cil.oc.api.internal
 import li.cil.oc.api.network.EnvironmentHost
-import li.cil.oc.common.Slot
-import li.cil.oc.common.Tier
+import li.cil.oc.common.{Slot, Tier}
 import li.cil.oc.server.component
+import li.cil.oc.{Constants, api}
 import net.minecraft.entity.Entity
 import net.minecraft.item.ItemStack
 
@@ -18,7 +17,7 @@ object DriverUpgradeLeash extends Item with HostAware {
   override def createEnvironment(stack: ItemStack, host: EnvironmentHost) =
     if (host.world != null && host.world.isRemote) null
     else host match {
-      case entity: Entity => new component.UpgradeLeash(entity)
+      case entity: Entity with internal.Drone => new component.UpgradeLeash(entity)
       case _ => null
     }
 

--- a/src/main/scala/li/cil/oc/server/component/UpgradeLeash.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeLeash.scala
@@ -2,7 +2,6 @@ package li.cil.oc.server.component
 
 import java.util
 import java.util.UUID
-
 import li.cil.oc.Constants
 import li.cil.oc.api.driver.DeviceInfo.DeviceAttribute
 import li.cil.oc.api.driver.DeviceInfo.DeviceClass
@@ -22,6 +21,8 @@ import li.cil.oc.util.ExtendedArguments._
 import li.cil.oc.util.ExtendedNBT._
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLiving
+import net.minecraft.init.Items
+import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.nbt.NBTTagString
 import net.minecraftforge.common.util.Constants.NBT
@@ -58,14 +59,26 @@ class UpgradeLeash(val host: Entity) extends AbstractManagedEnvironment with tra
     val nearBounds = position.bounds
     val farBounds = nearBounds.offset(side.getXOffset * 2.0, side.getYOffset * 2.0, side.getZOffset * 2.0)
     val bounds = nearBounds.union(farBounds)
-    entitiesInBounds[EntityLiving](classOf[EntityLiving], bounds).find(_.canBeLeashedTo(fakePlayer)) match {
-      case Some(entity) =>
-        entity.setLeashHolder(host, true)
-        leashedEntities += entity.getUniqueID
-        context.pause(0.1)
-        result(true)
-      case _ => result(Unit, "no unleashed entity")
+    val drone = host.asInstanceOf[Drone]
+    var hasLeash = false
+    for (index <- 0 to drone.inventory.getSizeInventory) {
+      val stack = drone.inventory.getStackInSlot(index)
+      if (stack.getItem == Items.LEAD) {
+        stack.shrink(1)
+        hasLeash = true
+      }
     }
+    if (hasLeash) {
+      entitiesInBounds[EntityLiving](classOf[EntityLiving], bounds).find(_.canBeLeashedTo(fakePlayer)) match {
+        case Some(entity) =>
+          entity.setLeashHolder(host, true)
+          leashedEntities += entity.getUniqueID
+          context.pause(0.1)
+          result(true)
+        case _ => result(Unit, "no unleashed entity")
+      }
+    }
+    result(Unit,"don't have any lead")
   }
 
   @Callback(doc = """function() -- Unleashes all currently leashed entities.""")
@@ -82,9 +95,18 @@ class UpgradeLeash(val host: Entity) extends AbstractManagedEnvironment with tra
   }
 
   private def unleashAll() {
+    var drone = host.asInstanceOf[Drone]
     entitiesInBounds(classOf[EntityLiving], position.bounds.grow(5, 5, 5)).foreach(entity => {
       if (leashedEntities.contains(entity.getUniqueID) && entity.getLeashHolder == host) {
         entity.clearLeashed(true, false)
+        for (index <- 0 to drone.inventory.getSizeInventory) {
+          val itemStack = drone.inventory.getStackInSlot(index)
+          if (itemStack == ItemStack.EMPTY) {
+            drone.inventory.setInventorySlotContents(index, new ItemStack(Items.LEAD))
+          } else {
+            itemStack.grow(1)
+          }
+        }
       }
     })
     leashedEntities.clear()

--- a/src/main/scala/li/cil/oc/server/component/UpgradeLeash.scala
+++ b/src/main/scala/li/cil/oc/server/component/UpgradeLeash.scala
@@ -85,7 +85,7 @@ class UpgradeLeash(val host: Entity with internal.Drone) extends AbstractManaged
 
   private def unleashAll() {
     entitiesInBounds(classOf[EntityLiving], position.bounds.grow(5, 5, 5)).foreach(entity => {
-      if (leashedEntities.contains(entity.getUniqueID) && entity.getLeashHolder == host.player()) {
+      if (leashedEntities.contains(entity.getUniqueID) && entity.getLeashHolder == host) {
         entity.clearLeashed(true, false)
         breakable {
           for (index <- 0 to host.mainInventory().getSizeInventory) {


### PR DESCRIPTION
Add simple lead judgment and usage to fix #3376 

This PR uses a for loop to find the lead in the drone inventory itself to ensure backwards compatibility. Otherwise, you can use the selectedSlot value to make an accurate judgment, but this method has no backward compatibility.

For this PR, a complete test program is needed. It is currently known that the leash function works normally. A logic bug in unleash has also been discovered. But cannot test leash and unleash at the same time