### PR TITLE
Add Proper Hostname Support

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/boot/94_shell.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/boot/94_shell.lua
@@ -1,6 +1,1 @@
--- there doesn't seem to be a reason to update $HOSTNAME after the init signal
--- as user space /etc/profile comes after this point anyways
-if require("filesystem").exists("/etc/hostname") then
-  loadfile("/bin/hostname.lua")("--update")
-end
 os.setenv("SHELL","/bin/sh.lua")

--- a/src/main/resources/assets/opencomputers/loot/openos/etc/profile.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/etc/profile.lua
@@ -8,6 +8,13 @@ if tty.isAvailable() then
     tty.clear()
   end
 end
+
+if fs.exists("/etc/hostname") then
+  local hostfile = io.open("/etc/hostname")
+  os.setenv("HOSTNAME",  hostfile:read("*l"))
+  os.setenv("HOSTNAME_SEPARATOR", ": ")
+end
+
 dofile("/etc/motd")
 
 shell.setAlias("dir", "ls")


### PR DESCRIPTION
The seemingly half-baked lua code that is meant to handle hostnames in /boot/94_shell.lua does not work, I have moved hostname setting to /etc/profile.lua and it simply reads one line from /etc/hostname and sets $HOSTNAME to that, the default $HOSTNAME_SEPARATOR is now ": ", you can set your hostname by running this command: echo "hostname" > /etc/hostname

After changing you hostname to "foobar" using the above method, upon reloading of the shell, your new prompt would be: foobar: /home #

This is a very minor and easy improvement and i hope it will not be too much trouble to merge into OpenOS, I have tested this and it works on my OC systems in 1.7.10