### PR TITLE
Added configurable network packet TTL

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1259,6 +1259,13 @@ opencomputers {
     # string from the clipboard (Shift+Ins on a screen with a keyboard).
     maxClipboard: 1024
 
+    # The TTL (Time-To-Live) upon creation of a network packet. When a packet
+    # passes through a Relay, its TTL is decremented. If a Relay receives a
+    # packet with a TTL of 0, the packet is dropped. Minimum value is 5.
+    # Note: increasing this value to large numbers may have an significant
+    # impact on performances.
+    initialNetworkPacketTTL: 5
+
     # The maximum size of network packets to allow sending via network cards.
     # This has *nothing to do* with real network traffic, it's just a limit
     # for the network cards, mostly to reduce the chance of computer with a

--- a/src/main/scala/li/cil/oc/Settings.scala
+++ b/src/main/scala/li/cil/oc/Settings.scala
@@ -346,6 +346,7 @@ class Settings(val config: Config) {
   val maxScreenWidth = config.getInt("misc.maxScreenWidth") max 1
   val maxScreenHeight = config.getInt("misc.maxScreenHeight") max 1
   val inputUsername = config.getBoolean("misc.inputUsername")
+  val initialNetworkPacketTTL = config.getInt("misc.initialNetworkPacketTTL") max 5
   val maxNetworkPacketSize = config.getInt("misc.maxNetworkPacketSize") max 0
   // Need at least 4 for nanomachine protocol. Because I can!
   val maxNetworkPacketParts = config.getInt("misc.maxNetworkPacketParts") max 4

--- a/src/main/scala/li/cil/oc/server/network/Network.scala
+++ b/src/main/scala/li/cil/oc/server/network/Network.scala
@@ -702,7 +702,7 @@ object Network extends api.detail.NetworkAPI {
 
   // ----------------------------------------------------------------------- //
 
-  class Packet(var source: String, var destination: String, var port: Int, var data: Array[AnyRef], var ttl: Int = 5) extends api.network.Packet {
+  class Packet(var source: String, var destination: String, var port: Int, var data: Array[AnyRef], var ttl: Int = Settings.get.initialNetworkPacketTTL) extends api.network.Packet {
     val size = Option(data).fold(0)(values => {
       if (values.length > Settings.get.maxNetworkPacketParts) {
         throw new IllegalArgumentException("packet has too many parts")


### PR DESCRIPTION
While I'm having a great time playing with OpenComputers in 1.12.2, I think the default network packet TTL is quite restrictive when thinking about building huge networks.
Upon searching for a way to fix the issue, I stumbled upon issue #2733 which is kind of related to what I wanted (that is, simply a higher base TTL).

I decided to take a quick look at the source code to see where the hard-coded TTL value was. As I was feeling quite comfortable modifying the code, I decided to make all changes in order to make it configurable by players.