### PR TITLE
Fix #3769

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/bin/pastebin.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/bin/pastebin.lua
@@ -22,7 +22,10 @@ local function get(pasteId, filename)
 
   io.write("Downloading from pastebin.com... ")
   local url = "https://pastebin.com/raw/" .. pasteId
-  local result, response = pcall(internet.request, url)
+
+  -- User agent added to impersonate real browsers and bypass anti-scraping protection
+  local result, response = pcall(internet.request, url, nil, {["User-Agent"]="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0"})
+
   if result then
     io.write("success.\n")
     for chunk in response do


### PR DESCRIPTION
Added user agent of a real browser (mine) to bypass what looks like an **anti-scraping protection**.
This is an *experimental* fix to avoid the 403 HTTP (forbidden access) code that is the hidden origin of that issue.
**Tested with the MineOS installer and the pastebin tested from #3769.**