### PR TITLE
Fix Juke box driver on 1.12

### DIFF
--- a/src/main/scala/li/cil/oc/integration/minecraft/DriverRecordPlayer.scala
+++ b/src/main/scala/li/cil/oc/integration/minecraft/DriverRecordPlayer.scala
@@ -43,7 +43,7 @@ object DriverRecordPlayer extends DriverSidedTileEntity {
     def play(context: Context, args: Arguments): Array[AnyRef] = {
       val record = tileEntity.getRecord
       if (record != null && record.getItem.isInstanceOf[ItemRecord]) {
-        tileEntity.getWorld.playEvent(null, 1005, tileEntity.getPos, Item.getIdFromItem(record.getItem))
+        tileEntity.getWorld.playEvent(null, 1010, tileEntity.getPos, Item.getIdFromItem(record.getItem))
         result(true)
       }
       else null
@@ -51,7 +51,7 @@ object DriverRecordPlayer extends DriverSidedTileEntity {
 
     @Callback(doc = "function() -- Stop playing the record currently in the jukebox.")
     def stop(context: Context, args: Arguments): Array[AnyRef] = {
-      tileEntity.getWorld.playEvent(1005, tileEntity.getPos, 0)
+      tileEntity.getWorld.playEvent(1010, tileEntity.getPos, 0)
       tileEntity.getWorld.playRecord(tileEntity.getPos, null)
       null
     }


### PR DESCRIPTION
Since minecraft 1.12 changed the SFX ID for the jukebox from 1005 to 1010 and reassigned the old SFX ID to the iron door opening sound, the OpenComputers adapter can no longer control jukebox playback properly. Attempting to play or stop playback triggers the iron door opening sound instead. This commit fixes the issue. It is currently unclear whether this issue exists in other versions.

Relevant code in 1.7.10:
![image](https://github.com/user-attachments/assets/d8482db2-e16f-45fa-8d97-72939a0892cc)

Relevant code in 1.12:
![image](https://github.com/user-attachments/assets/7615ef48-08c7-45f8-aaec-9ecd19326511)
![image](https://github.com/user-attachments/assets/c761c71f-1c0e-4b79-becf-0483e00996c5)
