### PR TITLE
fix `os.sleep(0)` causing `too long without yielding`

### DIFF
--- a/src/main/resources/assets/opencomputers/loot/openos/lib/event.lua
+++ b/src/main/resources/assets/opencomputers/loot/openos/lib/event.lua
@@ -143,7 +143,7 @@ function event.pullFiltered(...)
   local deadline = computer.uptime() + (seconds or math.huge)
   repeat
     local waitTime = deadline - computer.uptime()
-    if waitTime <= 0 then
+    if waitTime < 0 then
       break
     end
     local signal = table.pack(computer.pullSignal(waitTime))


### PR DESCRIPTION
It appears commit [7fecb07](https://github.com/MightyPirates/OpenComputers/commit/7fecb0732ce36b2e6246b5fd85ca298e00a79e2b) broke `os.sleep(0)`:

```lua
while true do os.sleep(0) end
```

as of oc 1.8.7/1.8.8 this cannot be interrupted, and will crash with `too long without yielding`, where in 1.8.6 and before this was not the case.  may fix #3773 