### PR TITLE
Fix TCP socket finishConnect() exception handling and connection logic

### DIFF
--- a/src/main/scala/li/cil/oc/server/component/InternetCard.scala
+++ b/src/main/scala/li/cil/oc/server/component/InternetCard.scala
@@ -329,7 +329,9 @@ object InternetCard {
     private def checkConnected() = {
       if (owner.isEmpty) throw new IOException("connection lost")
       try {
-        if (isAddressResolved) channel.finishConnect()
+        if (isAddressResolved) {
+          channel.finishConnect()
+        }
         else if (address.isCancelled) {
           // I don't think this can ever happen, Justin Case.
           channel.close()
@@ -341,14 +343,15 @@ object InternetCard {
             case e: ExecutionException => throw e.getCause
           }
           isAddressResolved = true
-          false
+          // After address resolution, immediately attempt connection
+          channel.finishConnect()
         }
         else false
       }
       catch {
         case t: Throwable =>
           close()
-          false
+          throw t  // Propagate exception instead of returning false
       }
     }
 


### PR DESCRIPTION
- Fix bug where finishConnect() required multiple calls before throwing exceptions
- Fix logic where address resolution didn't immediately attempt connection
- After address is resolved, immediately call channel.finishConnect()
- Ensures immediate error reporting for failed socket connections
- Improves reliability of socket connection error handling