### PR TITLE
Fix Redstone IO Block particle missing on destory

### DIFF
--- a/src/main/resources/assets/opencomputers/models/block/redstone.json
+++ b/src/main/resources/assets/opencomputers/models/block/redstone.json
@@ -6,6 +6,7 @@
         "north": "opencomputers:blocks/redstone_north",
         "south": "opencomputers:blocks/redstone_south",
         "west": "opencomputers:blocks/redstone_west",
-        "east": "opencomputers:blocks/redstone_east"
+        "east": "opencomputers:blocks/redstone_east",
+        "particle": "opencomputers:blocks/redstone_top"
     }
 }


### PR DESCRIPTION
Fixes #3792 